### PR TITLE
feat: add generate-slides-retro-simple skill

### DIFF
--- a/.claude/skills/build-marp-deck/SKILL.md
+++ b/.claude/skills/build-marp-deck/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: build-marp-deck
+description: Bouw of bewerk een Marp presentatie (.md → HTML/PDF) in de Npuls huisstijl, met live preview-server en visuele overflow-controle. Gebruik wanneer iemand "maak een marp", "bouw een deck", "marp presentatie", "preview", "preview venster", "live preview", "open de marp" vraagt, of /build-marp-deck aanroept. Bij een Marp-deck open je standaard de live preview-server (niet losse HTML in de browser). Voor Slidev gebruik je clidev; dit is puur Marp.
+---
+
+# Build Marp Deck
+
+Maak Marp presentaties in de CEDA/Npuls huisstijl. Marp rendert Markdown → slides via de
+`marp` CLI. Deze skill bundelt het `npuls` thema en de werkende slide-patronen, en bakt een
+**render → visueel checken → fixen** loop in zodat overflow niet stilletjes blijft staan.
+
+Marp is bewust **niet** Slidev. Wil iemand Slidev? → gebruik `clidev`.
+
+## Live preview (standaard tijdens bewerken)
+
+Zodra je een deck **bouwt of bewerkt**, start meteen de Marp preview-server in plaats van
+losse HTML in de browser te openen. De server heeft **live reload**: elke save aan de `.md`
+ververst het venster vanzelf — geen handmatige re-render per wijziging.
+
+```bash
+marp --preview --server .
+```
+
+Start dit **in de achtergrond** (Bash `run_in_background: true`), open daarna het deck direct:
+
+```bash
+open "http://localhost:8080/<deck>.md"
+```
+
+- `--server .` serveert de map (live reload); `--preview` opent het preview-venster.
+- Draait er al een server op 8080? Niet opnieuw starten — alleen de deck-URL openen.
+- Triggers: "preview", "preview mode", "preview venster", "live", "open de marp" → start dit,
+  niet de statische `deck.html` in de browser.
+
+Stoppen:
+
+```bash
+pkill -f "marp --preview"
+```
+
+> De statische render (`marp deck.md -o exports/deck.html` + `--pdf -o exports/deck.pdf`)
+> levert de **eindproducten** in de `exports/`-submap. Voor het iteratief bouwen/bekijken is
+> de HTML preview-server (live reload) of de PDF-watch (stap 3b) sneller.
+
+## Stap 1 — Setup (altijd eerst)
+
+Controleer of de `marp` CLI bestaat:
+
+```bash
+which marp || echo "niet aanwezig"
+```
+
+Niet aanwezig? Installeer:
+
+```bash
+brew install marp-cli
+```
+
+Kopieer het thema naar de projectmap als het er nog niet staat (assets zitten in deze skill):
+
+```bash
+SKILL_DIR="$HOME/.claude/skills/build-marp-deck/assets"
+[ -f npuls.css ]   || cp "$SKILL_DIR/npuls.css" .
+[ -f .marprc.yml ] || cp "$SKILL_DIR/.marprc.yml" .
+```
+
+`.marprc.yml` (`themeSet: [npuls.css]`) zorgt dat `marp` het thema automatisch laadt — geen
+`--theme` vlag nodig zolang je vanuit die map rendert.
+
+## Stap 2 — Schrijf de deck
+
+Begin elke deck met deze frontmatter:
+
+```yaml
+---
+marp: true
+theme: npuls
+paginate: true
+---
+```
+
+- Slides scheiden met `---` op een eigen regel.
+- Per-slide variant: `<!-- _class: X -->` bovenaan de slide (underscore = alléén deze slide).
+- Gebruik `assets/_template.md` als startpunt — die toont alle slide-classes in actie.
+
+### Slide-classes (uit `npuls.css`)
+
+| Class | Effect |
+|-------|--------|
+| `title` | Blauwe titelslide, gecentreerd (ondertitel roze) |
+| `divider` | Oranje full-bleed sectie-scheider, grote witte tekst |
+| `accent` | Groene slide met witte tekst |
+| `light-blue` / `light-pink` / `light-green` / `light-orange` / `light-yellow` | Zachte gekleurde achtergrond |
+| `dense` | Kleinere tabel/code/quote (0.70em) — bij veel inhoud |
+| `dense-table` | Alleen tabel kleiner |
+| `dense-code` | Alleen codeblok kleiner |
+
+`class` (zonder underscore) i.p.v. `_class` = geldt vanaf die slide tot je hem weer wijzigt.
+
+### Layout & helpers (rauwe HTML in de Markdown)
+
+```html
+<div class="columns">
+<div class="col"> … links … </div>
+<div class="col"> … rechts … </div>
+</div>
+```
+
+- `<div class="big-impact">85%</div>` — groot oranje kerngetal.
+- `<div class="medium-impact">…</div>` — blauwe subkop, gecentreerd.
+- `<div class="highlight-box"><h3>…</h3></div>` — blauw→oranje gradient kader.
+
+### Kleuren (`--npuls-*` vars)
+
+oranje `#DD784B` · blauw `#3D68EC` · groen `#00AF81` · geel `#F4D74B` · roze `#F4D9DC`.
+Standaard: H1/H2 oranje, `**strong**` en links blauw, tabel-header blauw met gestreepte rijen,
+blockquote oranje linkerrand.
+
+## Stap 3 — Render & visueel controleren
+
+Render de **eindproducten** naar de `exports/`-submap. De `.md` blijft in de hoofdmap; de
+`html`- én `pdf`-versies komen in `exports/`:
+
+```bash
+mkdir -p exports
+marp deck.md -o exports/deck.html
+marp deck.md --pdf -o exports/deck.pdf
+```
+
+Beide bestanden zijn eindproducten en **blijven staan** in `exports/`. De PDF dient
+tegelijk als overflow-check — niet meer weggooien.
+
+Lees de PDF met de **Read tool**, `pages "1-N"` (tot 20 per call), en controleer elke slide op:
+
+- inhoud die aan de onder-/rechterrand wordt **afgekapt** (overflow — Marp waarschuwt hier niet voor);
+- tekst die te klein of te groot is;
+- lege of onevenwichtige slides.
+
+**Fix overflow** in de `.md` en render opnieuw:
+- veel tekst → splits de slide in twee, of `<!-- _class: dense -->`;
+- brede tabel → `<!-- _class: dense-table -->`;
+- lang codeblok → `<!-- _class: dense-code -->`;
+- naast elkaar → `columns`.
+
+Herhaal render → Read → fix tot alle slides schoon zijn.
+
+> `exports/*.html` en `exports/*.pdf` erven automatisch het `npuls`-thema — Marp bakt de CSS
+> in elk bestand in. Geen aparte print-CSS nodig: de PDF-lay-out is identiek aan de HTML.
+
+### Stap 3b — PDF live-preview (wijzigingen direct zien)
+
+Wil je overflow live zien terwijl je bewerkt: render de PDF in **watch**-modus en open hem
+in een viewer die automatisch herlaadt.
+
+```bash
+marp deck.md --pdf -o exports/deck.pdf --watch
+```
+
+Start dit **in de achtergrond** (Bash `run_in_background: true`), open daarna de PDF:
+
+```bash
+open exports/deck.pdf
+```
+
+- `--watch` re-rendert de PDF bij elke save van de `.md`.
+- macOS **Preview** herlaadt een gewijzigde PDF meestal vanzelf; **Skim** doet dit het
+  betrouwbaarst (zet *Preferences → Sync → Check for file changes* aan).
+- De HTML preview-server is sneller voor tekst en flow; de PDF-watch toont de **echte
+  paginaranden** en dus de overflow.
+
+Stoppen: `pkill -f "marp.*--watch"`.
+
+## Bestaande deck updaten
+
+Bij het wijzigen van een bestaande deck: **sla stap 1 over** — `npuls.css` en `.marprc.yml`
+staan al naast de `.md`. Niet opnieuw kopiëren, niet overschrijven.
+
+1. Edit de `.md` gericht (Edit-tool, niet de hele file herschrijven).
+2. Re-render beide eindproducten: `marp deck.md -o exports/deck.html && marp deck.md --pdf -o exports/deck.pdf`.
+3. **Check alleen de geraakte slides** op overflow — lees de gewijzigde pagina's uit
+   `exports/deck.pdf` met de Read tool, fix waar nodig. De PDF blijft staan (geen opruimen).
+
+Grootste risico bij update: tekst toevoegen aan een bestaande slide duwt inhoud over de rand —
+Marp clipt stil. Neem nooit aan dat een geraakte slide nog past; check hem visueel.
+
+## Gotchas
+
+- **Overflow is stil.** Marp clipt zonder error. Altijd visueel checken (stap 3).
+- **`columns` vereist rauwe `<div>`-HTML**, geen Markdown-kolommen.
+- **`_class` vs `class`**: underscore = deze slide; zonder = vanaf deze slide.
+- **PDF/PNG-export vereist Chromium.** Chrome staat op deze Mac. Faalt export? Zet
+  `CHROME_PATH=/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` of geef `--browser chrome`.
+- **Lokale fonts** (`General Sans`, `Cooper Light BT`) vallen netjes terug op Plus Jakarta Sans
+  als ze ontbreken — geen blocker.
+- **Links/e-mails op donkere slides** (`accent`/`divider`/`title`) blijven blauw → laag contrast.
+  Schrijf contactgegevens als platte tekst, of vermijd links op gekleurde achtergronden.
+
+## Optioneel — programmatische overflow-check (Playwright/Chrome MCP)
+
+Wil je overflow detecteren zonder vision-tokens: open `deck.html` via een browser-MCP en meet
+per `section` of `scrollHeight > clientHeight`. Krachtiger voor grote decks, maar vereist een
+geconfigureerde MCP en mikken op Marp's bespoke DOM. De PDF+Read-loop hierboven is de standaard.
+
+## Benodigde permissies (verse machine)
+
+Voeg toe aan `~/.claude/settings.json` → `permissions.allow` voor prompt-vrij renderen:
+
+```json
+"Bash(marp:*)",
+"Bash(npx marp:*)",
+"Bash(which marp)",
+"Bash(brew install marp-cli:*)",
+"Bash(open:*)",
+"Bash(pkill:*)",
+"Read(**/*.pdf)"
+```
+
+`Bash(marp:*)` dekt ook de preview-server (`marp --preview --server .`); `Bash(open:*)` opent de
+deck-URL prompt-vrij; `Bash(pkill:*)` stopt de preview-server.
+
+`Read(**/*.pdf)` laat de PDF in `exports/` zonder prompt lezen. Het aanmaken van `exports/`
+en het kopiëren van assets (`mkdir`/`cp`) blijft prompt-on-first-use — bewust niet breed.

--- a/.claude/skills/build-marp-deck/assets/.marprc.yml
+++ b/.claude/skills/build-marp-deck/assets/.marprc.yml
@@ -1,0 +1,2 @@
+themeSet:
+  - npuls.css

--- a/.claude/skills/build-marp-deck/assets/_template.md
+++ b/.claude/skills/build-marp-deck/assets/_template.md
@@ -1,0 +1,89 @@
+---
+marp: true
+theme: npuls
+paginate: true
+---
+
+<!-- _class: title -->
+
+# Presentatietitel
+## Ondertitel of claim
+
+CEDA / Npuls AI & Data — 2026
+
+---
+
+# Inhoud
+
+1. Waar staan we?
+2. Het voorstel
+3. Aanpak en planning
+4. Bijlage
+
+---
+
+<!-- _class: divider -->
+
+# 1. Waar staan we?
+
+---
+
+# Twee kolommen
+
+<div class="columns">
+<div class="col">
+
+**Nu**
+
+- Lokaal en ad-hoc
+- Geen gedeelde standaard
+- Werk wordt dubbel gedaan
+
+</div>
+<div class="col">
+
+**Straks**
+
+- Gedeelde standaarden
+- Herbruikbare tooling
+- Eén bron van waarheid
+
+</div>
+</div>
+
+---
+
+# Een citaat
+
+> Standaardisatie is geen doel op zich, maar de voorwaarde voor schaal.
+
+Gewone tekst met **blauwe nadruk** en een [link](https://npuls.nl).
+
+---
+
+<!-- _class: dense-table -->
+
+# Tabel (dense voor veel rijen)
+
+| Onderdeel        | Status       | Eigenaar |
+|------------------|--------------|----------|
+| Architectuur     | Concept      | CEDA     |
+| Datastandaarden  | In uitvoering| Npuls    |
+| Adoptie-toolkit  | Gepland      | CEDA     |
+| Pilots           | Q3 2026      | Instellingen |
+
+---
+
+# Eén groot getal
+
+<div class="big-impact">85%</div>
+
+<div class="medium-impact">van de instellingen wil samenwerken aan standaarden</div>
+
+---
+
+<!-- _class: accent -->
+
+# Vragen?
+
+corneeldenhartogh@gmail.com

--- a/.claude/skills/build-marp-deck/assets/npuls.css
+++ b/.claude/skills/build-marp-deck/assets/npuls.css
@@ -1,0 +1,252 @@
+/* @theme npuls */
+@import 'default';
+
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&display=swap');
+
+@font-face {
+  font-family: 'General Sans';
+  src: local('General Sans Regular'), local('GeneralSans-Regular');
+  font-weight: 400;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'General Sans';
+  src: local('General Sans Semibold'), local('GeneralSans-Semibold');
+  font-weight: 600;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Cooper Light BT';
+  src: local('Cooper Light BT'), local('CooperLightBT');
+  font-weight: 300;
+  font-style: normal;
+}
+
+:root {
+  --npuls-orange: #DD784B;
+  --npuls-black: #000000;
+  --npuls-pink: #F4D9DC;
+  --npuls-blue: #3D68EC;
+  --npuls-yellow: #F4D74B;
+  --npuls-green: #00AF81;
+  --npuls-white: #FFFFFF;
+
+  --npuls-green-light: #CCEEE6;
+  --npuls-blue-light: #D6E2FD;
+  --npuls-pink-light: #FAEAEA;
+  --npuls-orange-light: #FFE4D8;
+  --npuls-yellow-light: #FCF5D4;
+}
+
+section {
+  font-family: 'General Sans', 'Plus Jakarta Sans', Arial, Helvetica, sans-serif;
+  font-size: 25px;
+  color: var(--npuls-black);
+  background-color: var(--npuls-white);
+  padding: 40px 50px;
+}
+
+/* Headings */
+
+section h1 {
+  color: var(--npuls-orange);
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+section h2 {
+  color: var(--npuls-orange);
+  font-weight: 600;
+}
+
+section h3,
+section h4,
+section h5,
+section h6 {
+  color: var(--npuls-black);
+  font-weight: 600;
+}
+
+/* Typography */
+
+section a {
+  color: var(--npuls-blue);
+  text-decoration: none;
+}
+
+section a:hover {
+  color: var(--npuls-orange);
+}
+
+section strong {
+  color: var(--npuls-blue);
+  font-weight: 600;
+}
+
+section blockquote {
+  font-family: 'Cooper Light BT', 'Plus Jakarta Sans', Georgia, serif;
+  font-weight: 300;
+  border-left: 4px solid var(--npuls-orange);
+  padding: 0.5em 1em;
+  margin: 1em 0;
+  background-color: var(--npuls-orange-light);
+  color: var(--npuls-black);
+  font-size: 0.9em;
+}
+
+/* Tables */
+
+section table {
+  font-size: 0.85em;
+  width: 100%;
+  border-collapse: collapse;
+}
+
+section table th {
+  background-color: var(--npuls-blue);
+  color: var(--npuls-white);
+  font-weight: 600;
+  padding: 0.4em 0.6em;
+  text-align: left;
+}
+
+section table td {
+  padding: 0.4em 0.6em;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+section table tr:nth-child(even) {
+  background-color: var(--npuls-blue-light);
+}
+
+/* Code blocks */
+
+section pre {
+  text-align: center;
+  border-left: 4px solid var(--npuls-blue);
+  border-radius: 0.5rem;
+  background-color: #f8f9fa;
+}
+
+section pre code {
+  display: inline-block;
+  text-align: left;
+}
+
+section code {
+  color: var(--npuls-blue);
+}
+
+/* Layout utilities */
+
+section .columns {
+  display: flex;
+  gap: 2em;
+}
+
+section .col {
+  flex: 1;
+}
+
+/* Slide variants */
+
+section.divider {
+  background-color: var(--npuls-orange);
+  color: var(--npuls-white);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+section.divider h1 {
+  color: var(--npuls-white);
+  font-size: 2.5em;
+}
+
+section.divider h2 {
+  color: var(--npuls-white);
+  font-weight: 400;
+}
+
+section.title {
+  background-color: var(--npuls-blue);
+  color: var(--npuls-white);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+section.title h1 {
+  color: var(--npuls-white);
+}
+
+section.title h2 {
+  color: var(--npuls-pink);
+  font-weight: 400;
+}
+
+section.accent {
+  background-color: var(--npuls-green);
+  color: var(--npuls-white);
+}
+
+section.accent h1 {
+  color: var(--npuls-white);
+}
+
+/* Light background variants */
+
+section.light-blue { background-color: var(--npuls-blue-light); }
+section.light-pink { background-color: var(--npuls-pink-light); }
+section.light-green { background-color: var(--npuls-green-light); }
+section.light-orange { background-color: var(--npuls-orange-light); }
+section.light-yellow { background-color: var(--npuls-yellow-light); }
+
+/* Helper classes */
+
+section .big-impact {
+  font-size: 3.5rem;
+  font-weight: 700;
+  color: var(--npuls-orange);
+  line-height: 1.1;
+  text-align: center;
+}
+
+section .medium-impact {
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--npuls-blue);
+  text-align: center;
+}
+
+section .highlight-box {
+  background: linear-gradient(135deg, var(--npuls-blue) 0%, var(--npuls-orange) 100%);
+  padding: 1rem;
+  border-radius: 0.75rem;
+  color: white;
+  text-align: center;
+}
+
+section .highlight-box h3 {
+  color: white;
+}
+
+/* Density helpers */
+
+section.dense-table table { font-size: 0.70em; }
+section.dense-code pre { font-size: 0.70em; }
+section.dense table,
+section.dense pre,
+section.dense blockquote { font-size: 0.70em; }
+
+/* Pagination */
+
+section::after {
+  color: var(--npuls-blue);
+  font-size: 0.7em;
+}

--- a/.claude/skills/generate-slides-retro-simple/SKILL.md
+++ b/.claude/skills/generate-slides-retro-simple/SKILL.md
@@ -1,0 +1,451 @@
+---
+name: generate-slides-retro-simple
+description: Genereer een compacte, inhoudelijke Slidev sprint review presentatie voor CEDA, georganiseerd per domein (instroom/uitval/tech/project) met substantiemetriek op basis van commits, functies en het CEDA Board.
+---
+
+# generate-slides-retro-simple
+
+Genereer een compacte sprint review presentatie voor CEDA, georganiseerd per domein met focus op wat er daadwerkelijk is opgeleverd.
+
+## Instructies
+
+### Stap 0: Clone het clidev project
+
+1. Zoek of het project al ergens op de machine staat:
+   ```bash
+   find ~ -type f -name "_template.md" 2>/dev/null | xargs -I{} dirname {} | while read dir; do
+     [ -d "$dir/theme" ] && [ -d "$dir/public/npuls" ] && echo "$dir"
+   done | head -3
+   ```
+2. Als het niet gevonden wordt, clone het:
+   ```bash
+   git clone https://github.com/cedanl/clidev-presentaties.git ~/clidev-presentaties
+   ```
+3. Installeer dependencies als `node_modules/` ontbreekt:
+   ```bash
+   cd <project-pad> && npm install
+   ```
+4. Genereer de presentatie **in deze directory** met `theme: ./theme`. Naamconventie: `YYMMDD_sprint_review_simple.md`.
+
+### Stap 1: GitHub Token check & sprint-periode
+
+**Token check — voer dit uit VOORDAT je data ophaalt:**
+1. Controleer of `$GITHUB_TOKEN` is ingesteld (`echo $GITHUB_TOKEN`).
+2. Als het NIET is ingesteld, vraag de gebruiker:
+   > Je hebt een GitHub Personal Access Token nodig. Heb je er al een?
+   >
+   > **Zo niet, maak er een aan:**
+   > 1. Ga naar https://github.com/settings/tokens
+   > 2. Klik op **"Generate new token (classic)"**
+   > 3. Selecteer minimaal de scopes **`repo`** en **`read:org`** en **`project`**
+   > 4. Klik op **"Generate token"** en kopieer het token
+   >
+   > **Plak je GitHub token hier in de chat:**
+3. Zodra de gebruiker het token plakt:
+   ```bash
+   export GITHUB_TOKEN="<geplakt-token>"
+   ```
+4. Verifieer:
+   ```bash
+   curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/user | grep login
+   ```
+
+**Iteratie-periode ophalen van CEDA Board:**
+
+Haal de actieve iteratie op van het CEDA Board (project #2) via GraphQL:
+
+```bash
+gh api graphql -f query='
+{
+  organization(login: "cedanl") {
+    projectV2(number: 2) {
+      field(name: "Iteratie") {
+        ... on ProjectV2IterationField {
+          configuration {
+            iterations {
+              id
+              title
+              startDate
+              duration
+            }
+            completedIterations {
+              id
+              title
+              startDate
+              duration
+            }
+          }
+        }
+      }
+    }
+  }
+}
+'
+```
+
+- Gebruik de huidige/meest recente iteratie om `SPRINT_START` en `SPRINT_END` te bepalen
+- `SPRINT_START` = `startDate` van de iteratie
+- `SPRINT_END` = `startDate` + `duration` dagen
+- Het veld heet "Iteratie" (Nederlands), niet "Iteration"
+- Als er geen iteratie-veld is, val terug op 2 weken eindigend op vandaag
+- Toon de iteratie-titel (bijv. "Sprint 12") in de presentatie
+
+**Repo's ophalen en filteren:**
+- Haal alle repos op: `curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/orgs/cedanl/repos?per_page=100&type=public"`
+- Werk `config.json` bij met de resultaten.
+- Pre-filter: alleen repo's waar `pushed_at >= SPRINT_START`.
+
+### Stap 2: Categorie-mapping
+
+Elke actieve repo wordt gemapt naar 1 van 5 domeinen:
+
+| Domein | Kleur | Repos (pattern match) |
+|--------|-------|----------------------|
+| **instroom** | `#1D76DB` | `*instroom*`, `*prognose*`, `student-instroom-mbo`, `dashboard-instroomprognose-mbo` |
+| **uitval** | `#D93F0B` | `*1cijfer*`, `*1cho*`, `*uitval*`, `*vsv*`, `*uitnodiging*`, `no-fairness-without-awareness`, `lta-hhs-fairnessawareness`, `Assistentie`, `student-signal` |
+| **tech** | `#5319E7` | `*template*`, `*devcontainer*`, `sdp-tools`, `ceda-scoop`, `maak_een_hex`, `docker_1cho` |
+| **project** | `#0E8A16` | `project_algemeen`, `ceda-algemeen`, `communicatie`, `.github`, `clidev-presentaties`, `public_activities`, `centre_documentation`, `regiobijeenkomsten` |
+| **overig** | `#757575` | `arbeidsmarkt-mbo`, `cbs-onderwijsdata`, `overzicht-landelijke-databronnen`, `samenwijzer`, `eencijfer`, `textanalysis` |
+
+Fallback voor onbekende repos: `overig`.
+
+### Stap 3: Data ophalen
+
+Haal 4 databronnen op voor alle actieve repo's:
+
+#### A. Commits op main
+
+Per actieve repo:
+```bash
+gh api "repos/cedanl/{repo}/commits?sha=main&since={SPRINT_START}&until={SPRINT_END}&per_page=100" \
+  --jq '.[] | {sha: .sha, author: .author.login, message: .commit.message, date: .commit.author.date}'
+```
+
+Verzamel per repo:
+- Totaal aantal commits
+- Unieke contributors (GitHub usernames)
+- Avatar URL per contributor: `https://github.com/{username}.png`
+
+#### B. CEDA Board status via GraphQL
+
+Haal alle items op van het CEDA Board (project #2) inclusief hun status:
+
+```bash
+gh api graphql -f query='
+query($cursor: String) {
+  organization(login: "cedanl") {
+    projectV2(number: 2) {
+      items(first: 100, after: $cursor) {
+        nodes {
+          status: fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue {
+              name
+            }
+          }
+          iteratie: fieldValueByName(name: "Iteratie") {
+            ... on ProjectV2ItemFieldIterationValue {
+              title
+            }
+          }
+          content {
+            ... on Issue {
+              number
+              title
+              state
+              closedAt
+              url
+              body
+              repository {
+                name
+              }
+              issueType {
+                name
+              }
+              assignees(first: 5) {
+                nodes {
+                  login
+                }
+              }
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+'
+```
+
+**Let op:** gebruik GraphQL aliases (`status:` en `iteratie:`) omdat je twee `fieldValueByName` calls nodig hebt.
+
+Filter items op `iteratie.title == {huidige iteratie titel}` om alleen items van de actieve iteratie te tonen.
+
+Als `hasNextPage` true is, pagineer met `after: $endCursor`.
+
+Verzamel per board item:
+- Status: Done / In Progress / Todo / On Hold
+- Issue type: Pitch / Task / Bug (uit `issueType.name`)
+- Repo naam (voor categorie-mapping)
+- Assignees (voor avatars)
+- `closedAt` (voor filtering op sprint-periode)
+- `body` (voor scope-analyse bij Pitches)
+
+#### C. Functie-metric (20-100 regels) — alleen TOEGEVOEGDE code
+
+Per actieve repo met commits, haal de diff op:
+
+1. Bepaal het eerste commit SHA voor de sprint:
+```bash
+FIRST_SHA=$(gh api "repos/cedanl/{repo}/commits?sha=main&until={SPRINT_START}&per_page=1" --jq '.[0].sha')
+```
+
+2. Haal de compare op en filter op Python/R bestanden:
+```bash
+gh api "repos/cedanl/{repo}/compare/{FIRST_SHA}...main" \
+  --jq '.files[] | select(.filename | test("\\.(py|R|r)$")) | {filename, patch}'
+```
+
+3. Analyseer alleen de `+` regels uit elke patch (toegevoegde code):
+   - **Python**: zoek naar `def ` blokken en tel regels tot het volgende `def`/`class` of dedent
+   - **R**: zoek naar `<- function(` of `= function(` blokken en tel regels tot de sluitende `}`
+   - Tel alleen functies van **20-100 regels**
+
+4. Dit is een proxy voor "echte logica toegevoegd" — niet boilerplate, niet one-liners, niet monolithen.
+
+5. Rapporteer per repo: "N functies (20-100 regels) toegevoegd"
+
+#### D. Bestanden geraakt
+
+Uit dezelfde compare API response:
+```bash
+gh api "repos/cedanl/{repo}/compare/{FIRST_SHA}...main" --jq '[.files[].filename] | length'
+```
+
+Context indicator (geen waardeoordeel):
+- Breed (>20 bestanden) = feature/integratie werk
+- Smal (<5 bestanden) = bugfix/refactor
+
+### Stap 4: Metrics berekenen
+
+1. **Opgeleverd**: Board items met Status=Done waarvan `closedAt` in de sprint-periode valt. Groepeer per type:
+   - Pitches afgerond
+   - Tasks afgerond
+   - Bugs afgerond
+   - **Ratio**: done / (done + in_progress + todo) — dit is de delivery ratio
+
+2. **Toevoegingen**: Totaal functies 20-100 regels per domein.
+
+3. **Scope per pitch**: Per Pitch op het board:
+   - Check de issue body voor tasklists: `- [ ]` (open) en `- [x]` (done)
+   - Check voor issue referenties (`#123`) in de body
+   - Tel done vs totaal sub-items
+   - Toont of een pitch echt af is of half
+
+4. **Bestanden geraakt**: Totaal unieke files per domein.
+
+### Stap 5: Genereer slides
+
+**BELANGRIJK: Geen `<script>` of `<style>` tags in Slidev markdown slides!**
+Alleen statische HTML (divs, tables, inline styles) direct in de slide markdown.
+
+Genereer `YYMMDD_sprint_review_simple.md` in het clidev project met `theme: ./theme` in de frontmatter.
+
+#### Slide 1 — Titel + Overzicht
+
+"CEDA Sprint Review" + datum + sprint-periode.
+
+5 domein-blokken naast elkaar (flex layout), elk met:
+- Domeinnaam + kleur als `border-left: 4px solid {kleur}`
+- Aantal commits + bestanden
+- Contributor avatars (ronde `<img>` tags)
+
+Onderaan 3 hero-getallen:
+- **Opgeleverd**: done items count + ratio badge
+- **Toevoegingen**: totaal functies 20-100 regels
+- **Bestanden geraakt**: totaal unieke files
+
+#### Slide 2 — Uitval & Instroom
+
+Twee kolommen layout. Per domein:
+- **Commits**: count + korte samenvatting van belangrijkste commit messages (2-3 bullets)
+- **Functies 20-100r**: count + "substantieve logica toegevoegd"
+- **Bestanden**: count + breed/smal indicator
+- **Contributors**: avatar rij
+
+#### Slide 3 — Tech & Project
+
+Zelfde twee-kolommen layout als slide 2 voor de domeinen tech en project.
+
+#### Slide 4 — Overig
+
+Halve slide (1 kolom, max 50% breedte). Zelfde metrics als andere domeinslides.
+
+#### Slide 5 — Scope per Pitch (Kanban)
+
+Kanban board met 4 gelijke kolommen in deze volgorde:
+1. **Todo** (rood, `#C62828`) — pitches die nog niet gestart zijn
+2. **In Progress** (blauw, `#1565C0`) — pitches in uitvoering
+3. **Done** (groen, `#2E7D32`) — opgeleverde pitches
+4. **On Hold** (grijs, `#757575`) — geparkeerde pitches
+
+**Alleen pitches**, geen tasks of bugs. Elke pitch als tegel met:
+- Titel (aanklikbaar naar GitHub issue)
+- Repo referentie + assignee avatars
+- Domein-kleur als `border-left`
+
+Alle 4 kolommen `flex: 1` (even groot).
+
+#### Slide 6 — Toevoegingen
+
+Tabel met per domein: commits, functies 20-100r, bestanden, scope (breed/smal), top repo.
+- Totaalrij onderaan
+- Leeswijzer: breed = feature/integratie, smal = bugfix/refactor
+- Geen waardeoordeel, alleen context
+
+#### Slide 7 — Afgeronde tasks
+
+Tasks en bugs die los van een pitch zijn opgeleverd deze iteratie:
+- Per item: type-badge (Task/Bug), titel, repo referentie, assignee avatar
+- Aanklikbaar naar GitHub issue
+- Onderaan: overzicht van open tasks deze iteratie (als context)
+
+#### Slide 8 — Afsluiting
+
+- "Vragen?"
+- Alle contributor avatars in een grid
+- Link naar github.com/cedanl
+
+### Stap 6: Terminal summary
+
+Naast de presentatie, print een compact markdown overzicht in de terminal:
+
+```
+## CEDA Sprint Review — {start} - {end}
+
+### Opgeleverd: X/Y (Z%)
+  Pitches: A/B | Tasks: C/D | Bugs: E/F
+
+### Per domein
+| Domein    | Commits | Functies (20-100r) | Bestanden | Contributors       |
+|-----------|---------|--------------------|-----------|---------------------|
+| instroom  |      12 |                  4 |        18 | @user1 @user2       |
+| uitval    |       8 |                  2 |         7 | @user3              |
+| tech      |      15 |                  6 |        32 | @user1 @user4       |
+| project   |       3 |                  0 |         5 | @user2              |
+
+### Scope per Pitch
+- [x] Pitch A (instroom): 3/3 sub-items
+- [ ] Pitch B (uitval): 1/4 sub-items
+- [ ] Pitch C (tech): 2/5 sub-items
+```
+
+## Visuele componenten
+
+### Slide layout patroon
+
+Elke slide gebruikt achtergrond + absolute positioned content:
+
+```html
+<div style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: -1;">
+  <img src="/npuls/powerpoint_slides/SlideX.PNG" style="width: 100%; height: 100%; object-fit: cover;" />
+</div>
+
+<div style="position: absolute; inset: 0; display: flex; flex-direction: column; justify-content: center; padding: 2rem 4rem; z-index: 1;">
+  <!-- content hier -->
+</div>
+```
+
+Achtergronden:
+- `Slide1.PNG` — Titel (eerste en laatste slide)
+- `Slide3.PNG` — Content slides
+- `Slide5.PNG` — Overzicht slides (tabellen)
+
+### Avatar
+
+```html
+<img src="https://github.com/{user}.png"
+     style="width: 28px; height: 28px; border-radius: 50%; border: 2px solid #fff; box-shadow: 0 1px 3px rgba(0,0,0,0.1); margin-left: -6px;"
+     title="{user}" />
+```
+
+### Domein-kaart
+
+```html
+<div style="background: rgba(255,255,255,0.9); border-left: 4px solid {KLEUR}; border-radius: 8px; padding: 0.8rem 1rem; margin-bottom: 0.6rem;">
+  <div style="display: flex; justify-content: space-between; align-items: center;">
+    <span style="font-weight: bold; font-size: 0.85rem; color: {KLEUR};">{DOMEIN}</span>
+    <span style="font-size: 0.65rem; color: #666;">{N} commits | {M} bestanden</span>
+  </div>
+  <p style="font-size: 0.65rem; color: #333; margin: 0.3rem 0;">{SAMENVATTING}</p>
+  <div style="display: flex; gap: 0.3rem; align-items: center;">
+    <!-- avatars hier -->
+  </div>
+</div>
+```
+
+### Delivery ratio bar
+
+```html
+<div style="display: flex; align-items: center; gap: 0.5rem;">
+  <div style="flex: 1; background: #E0E0E0; border-radius: 4px; height: 12px;">
+    <div style="background: #2E7D32; height: 100%; width: {PERCENTAGE}%; border-radius: 4px;"></div>
+  </div>
+  <span style="font-size: 0.6rem; font-weight: bold;">{DONE}/{TOTAL}</span>
+</div>
+```
+
+### Type badges
+
+```html
+<!-- Pitch badge -->
+<span style="background: #6A1B9A; color: #fff; padding: 0.1rem 0.4rem; border-radius: 8px; font-size: 0.55rem; font-weight: bold;">Pitch</span>
+<!-- Task badge -->
+<span style="background: #1565C0; color: #fff; padding: 0.1rem 0.4rem; border-radius: 8px; font-size: 0.55rem; font-weight: bold;">Task</span>
+<!-- Bug badge -->
+<span style="background: #C62828; color: #fff; padding: 0.1rem 0.4rem; border-radius: 8px; font-size: 0.55rem; font-weight: bold;">Bug</span>
+```
+
+### Pitch scope card
+
+```html
+<div style="background: rgba(255,255,255,0.9); border-radius: 8px; padding: 0.6rem 1rem; margin-bottom: 0.5rem; box-shadow: 0 1px 4px rgba(0,0,0,0.06);">
+  <div style="display: flex; justify-content: space-between; align-items: center;">
+    <span style="font-weight: bold; font-size: 0.75rem;">{PITCH_TITEL}</span>
+    <span style="font-size: 0.55rem; background: {STATUS_KLEUR}; color: #fff; padding: 0.1rem 0.4rem; border-radius: 8px;">{STATUS}</span>
+  </div>
+  <div style="font-size: 0.6rem; color: #666; margin: 0.2rem 0;">{REPO} | {DONE}/{TOTAL} sub-items</div>
+  <!-- delivery ratio bar hier -->
+</div>
+```
+
+### Domein kleuren
+
+| Domein | Kleur | Licht |
+|--------|-------|-------|
+| instroom | `#1D76DB` | `#E3F2FD` |
+| uitval | `#D93F0B` | `#FBE9E7` |
+| tech | `#5319E7` | `#EDE7F6` |
+| project | `#0E8A16` | `#E8F5E9` |
+| overig | `#757575` | `#F5F5F5` |
+
+## Bestanden
+
+- `config.json` — Alle cedanl-repositories (wordt bijgewerkt bij elke run)
+- `<clidev-pad>/YYMMDD_sprint_review_simple.md` — Slidev-presentatie (output)
+- `<clidev-pad>/theme/` — Npuls huisstijl
+- `<clidev-pad>/public/` — Afbeeldingen en logo's
+
+## Presentatie starten
+
+De server moet in een aparte terminal gestart worden:
+
+```bash
+cd <clidev-pad>
+npx slidev YYMMDD_sprint_review_simple.md --open
+```
+
+De presentatie opent op http://localhost:3030.

--- a/.claude/skills/generate-slides-retro-simple/SKILL.md
+++ b/.claude/skills/generate-slides-retro-simple/SKILL.md
@@ -237,7 +237,7 @@ Context indicator (geen waardeoordeel):
    - Bugs afgerond
    - **Ratio**: done / (done + in_progress + todo) — dit is de delivery ratio
 
-2. **Toevoegingen**: Totaal functies 20-100 regels per domein.
+2. **Iteratie Output**: Totaal functies 20-100 regels per domein.
 
 3. **Scope per pitch**: Per Pitch op het board:
    - Check de issue body voor tasklists: `- [ ]` (open) en `- [x]` (done)
@@ -265,7 +265,7 @@ Genereer `YYMMDD_sprint_review_simple.md` in het clidev project met `theme: ./th
 
 Onderaan 3 hero-getallen:
 - **Opgeleverd**: done items count + ratio badge
-- **Toevoegingen**: totaal functies 20-100 regels
+- **Iteratie Output**: totaal functies 20-100 regels
 - **Bestanden geraakt**: totaal unieke files
 
 #### Slide 2 — Uitval & Instroom
@@ -299,12 +299,13 @@ Kanban board met 4 gelijke kolommen in deze volgorde:
 
 Alle 4 kolommen `flex: 1` (even groot).
 
-#### Slide 6 — Toevoegingen
+#### Slide 6 — Iteratie Output
 
-Tabel met per domein: commits, functies 20-100r, bestanden, scope (breed/smal), top repo.
+Tabel met per domein: commits, functies 20-100r, bestanden, scope (breed/smal), top repo(s).
 - Totaalrij onderaan
-- Leeswijzer: breed = feature/integratie, smal = bugfix/refactor
+- Leeswijzer onder de tabel met per kolom een korte toelichting (domein = welke repo's, commits = op default branch, functies = 20-100r proxy, bestanden = unieke files, scope = breed/smal, top repo(s) = getal = aantal functies)
 - Geen waardeoordeel, alleen context
+- Gebruik "geen output" (niet "geen activiteit") voor domeinen zonder commits — er kan wel werk zijn maar niets opgeleverd
 
 #### Slide 7 — Afgeronde tasks
 

--- a/.claude/skills/generate-slides-retro-simple/config.json
+++ b/.claude/skills/generate-slides-retro-simple/config.json
@@ -1,0 +1,212 @@
+[
+  {
+    "name": "ed2c-python",
+    "pushed_at": "2023-06-30T07:14:39Z",
+    "description": "Python packages for ed2c"
+  },
+  {
+    "name": "1cho_ins_preparation_r",
+    "pushed_at": "2026-03-05T13:00:17Z",
+    "description": " This is a repo for the Institutional 1 Cijfer HO (1CHO) data. This repository is for preparation of this data with R."
+  },
+  {
+    "name": "1cho_nl_visualisation_tableau",
+    "pushed_at": "2023-11-21T15:42:43Z",
+    "description": "This is a repo for the Dutch (national) 1 Cijfer HO (1CHO) data. This data is only for internal use. This repository is for visualisations of this data with Tableau"
+  },
+  {
+    "name": "1cho_nl_preparation_r",
+    "pushed_at": "2023-11-21T15:54:00Z",
+    "description": "This is a repo for the Dutch (national) 1 Cijfer HO (1CHO) data. This data is only for internal use. This repository is for preparation of these files with R."
+  },
+  {
+    "name": "1cho_ins_visualisation_tableau",
+    "pushed_at": "2023-11-21T17:06:24Z",
+    "description": "This is a repo for the Institutional 1 Cijfer HO (1CHO) data. This repository is for visualisation of this data with Tableau."
+  },
+  {
+    "name": "centre_documentation",
+    "pushed_at": "2024-12-10T20:41:45Z",
+    "description": "This is a repo for mostly Quarto documentation about the ways of working within CEDA"
+  },
+  {
+    "name": "wisselstroom",
+    "pushed_at": "2025-07-14T12:46:27Z",
+    "description": "use the bekostigingsbestanden to gain insight in switching studies"
+  },
+  {
+    "name": "docker_1cho",
+    "pushed_at": "2024-12-18T09:19:14Z",
+    "description": "Docker image which prepares raw 1cho files"
+  },
+  {
+    "name": "demo-instroomprognose",
+    "pushed_at": "2024-04-24T13:50:34Z",
+    "description": null
+  },
+  {
+    "name": "studentprognose",
+    "pushed_at": "2026-03-13T17:00:20Z",
+    "description": null
+  },
+  {
+    "name": "1cho_ins_visualisation_powerbi",
+    "pushed_at": "2025-01-28T12:56:07Z",
+    "description": "A ready to use powerBI dashboard, which visualises the 1cHO_instellingsbestand as is."
+  },
+  {
+    "name": "wisselstroom_demo",
+    "pushed_at": "2025-07-14T07:04:27Z",
+    "description": "R project to demonstrate the use of  `wisselstroom` package with example script"
+  },
+  {
+    "name": "public_activities",
+    "pushed_at": "2024-09-30T14:31:16Z",
+    "description": "A repository for the presentations of CEDA"
+  },
+  {
+    "name": "eencijfer",
+    "pushed_at": "2025-01-31T15:44:20Z",
+    "description": "ETL-tools for Dutch eencijfer"
+  },
+  {
+    "name": ".github",
+    "pushed_at": "2026-03-17T12:43:28Z",
+    "description": "Readme repository for CEDA main page"
+  },
+  {
+    "name": "overzicht-landelijke-databronnen",
+    "pushed_at": "2026-02-02T13:47:39Z",
+    "description": "Een overzicht van beschikbare data in het onderwijs"
+  },
+  {
+    "name": "maak_een_hex",
+    "pushed_at": "2024-12-05T14:32:38Z",
+    "description": null
+  },
+  {
+    "name": "powerbi-vsv",
+    "pushed_at": "2024-12-18T09:30:00Z",
+    "description": "Powerbi dashboard voor voortijdig schoolverlaters MBO op basis van DUO data."
+  },
+  {
+    "name": "Uitnodigingsregel",
+    "pushed_at": "2026-03-16T11:44:12Z",
+    "description": "Python project for predicting student dropout in the first year"
+  },
+  {
+    "name": "textanalysis",
+    "pushed_at": "2025-09-18T08:55:06Z",
+    "description": "Text Analysis Streamlit Dashboard (Local). Runs with uv"
+  },
+  {
+    "name": "vsv_analysis",
+    "pushed_at": "2025-09-08T08:22:25Z",
+    "description": "Een repository voor het inladen en bewerken van de voortijdig school verlaters data van DUO"
+  },
+  {
+    "name": "streamlit-app-template",
+    "pushed_at": "2025-06-19T10:59:31Z",
+    "description": "A production-ready template for building & deploying Streamlit apps with best practices and essential configurations. Runs with uv"
+  },
+  {
+    "name": "r-p3-template",
+    "pushed_at": "2025-02-18T15:33:10Z",
+    "description": "A template for structuring R projects"
+  },
+  {
+    "name": "instroomprognose-mbo",
+    "pushed_at": "2026-01-23T12:45:38Z",
+    "description": "Inladen en bewerken van data uit CAMBO om prognose te maken "
+  },
+  {
+    "name": "lta-hhs-fairnessawareness",
+    "pushed_at": "2025-03-10T14:23:27Z",
+    "description": "Repo voor het maken van fairness analyses"
+  },
+  {
+    "name": "1cijferho",
+    "pushed_at": "2026-03-18T12:09:17Z",
+    "description": "Snel en zorgvuldig aan de slag met 1cijferHO-data voor onderwijsanalyses en onderzoek."
+  },
+  {
+    "name": "student-instroom-mbo",
+    "pushed_at": "2026-02-20T01:04:16Z",
+    "description": null
+  },
+  {
+    "name": "sdp-tools",
+    "pushed_at": "2025-10-14T04:52:23Z",
+    "description": "Tools for the Surf Developer Platform"
+  },
+  {
+    "name": "Uitnodigingsregel_datapreparatie",
+    "pushed_at": "2025-10-07T14:01:28Z",
+    "description": "Data preparatie scripts voor de Uitnodigingsregel"
+  },
+  {
+    "name": "no-fairness-without-awareness",
+    "pushed_at": "2026-03-18T14:15:25Z",
+    "description": "Minimum Viable Product voor NFWA project"
+  },
+  {
+    "name": "studentjourney-mbo",
+    "pushed_at": "2026-01-09T15:02:10Z",
+    "description": "A pipeline for analyzing student journey in the Netherlands"
+  },
+  {
+    "name": "arbeidsmarkt-mbo",
+    "pushed_at": "2026-01-22T20:18:17Z",
+    "description": "Python project for labor market analysis and MBO enrollment forecasts"
+  },
+  {
+    "name": "python-uv-devcontainer",
+    "pushed_at": "2026-03-18T11:37:31Z",
+    "description": "Een minimale development container voor Python-projecten met uv als package manager."
+  },
+  {
+    "name": "r-devcontainer",
+    "pushed_at": "2026-03-18T11:37:39Z",
+    "description": "Een minimale devcontainer voor R"
+  },
+  {
+    "name": "communicatie",
+    "pushed_at": "2026-02-11T16:50:23Z",
+    "description": "Repository voor projectcommunicatie"
+  },
+  {
+    "name": "ceda-algemeen",
+    "pushed_at": "2026-02-11T16:53:01Z",
+    "description": "Project repository"
+  },
+  {
+    "name": "project_algemeen",
+    "pushed_at": "2026-02-16T12:06:32Z",
+    "description": "Verzamelplek voor alle projectmatige issues die niet bij code, communicatie of een andere specifieke repositories horen"
+  },
+  {
+    "name": "Assistentie",
+    "pushed_at": "2026-03-18T14:18:39Z",
+    "description": "Centrum Educatieve Digitale Assistentie"
+  },
+  {
+    "name": "dashboard-instroomprognose-mbo",
+    "pushed_at": "2026-03-10T08:52:53Z",
+    "description": null
+  },
+  {
+    "name": "ceda-scoop",
+    "pushed_at": "2026-03-15T20:48:54Z",
+    "description": "Repository voor een R project met scoop script om eenvoudig lokaal te installeren"
+  },
+  {
+    "name": "clidev-presentaties",
+    "pushed_at": "2026-03-18T10:57:28Z",
+    "description": "Repository met alle slides van CEDA ontwikkelt met slidev"
+  },
+  {
+    "name": "prep1cho",
+    "pushed_at": "2026-03-11T10:59:14Z",
+    "description": "Repository om de 1CHO data afkomstig uit project cedanl/1cijferho te verrijken in R"
+  }
+]


### PR DESCRIPTION
## Summary

- Nieuwe Claude Code skill voor compacte sprint review presentaties, georganiseerd per domein (instroom/uitval/tech/project/overig)
- Integreert met CEDA Board via GraphQL: iteratie-periodes, pitch/task/bug status, kanban view
- Bevat functie-metric (20-100 regels), bestanden geraakt, delivery ratio en contributor avatars
- Voorbeeld output: [`260408_sprint_review_simple.md`](https://github.com/cedanl/clidev-presentaties/blob/main/260408_sprint_review_simple.md)

## Slide structuur

1. Titel + Overzicht (5 domeinen + hero-getallen)
2. Uitval & Instroom (twee kolommen)
3. Tech & Project (twee kolommen)
4. Overig (halve slide)
5. Scope per Pitch (kanban: Todo/In Progress/Done/On Hold, alleen pitches)
6. Toevoegingen (tabel met functies, commits, bestanden per domein)
7. Afgeronde tasks (losse tasks buiten pitches)
8. Afsluiting

## Test plan

- [x] Run `/generate-slides-retro-simple` in een nieuwe sessie
- [x] Controleer dat GraphQL query met aliases correct data teruggeeft
- [x] Controleer dat gegenereerde `.md` opent met `npx slidev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)