### PR TITLE
grafiekkeuze-skill toevoegen aan gedeelde CEDA-skills

### DIFF
--- a/.claude/skills/grafiekkeuze/SKILL.md
+++ b/.claude/skills/grafiekkeuze/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: grafiekkeuze
+description: Use when choosing/recommending a chart or graph type to present data, or generating chart code. Triggers like "welke grafiek/diagram", "hoe visualiseer/presenteer ik deze data", "maak een grafiek/visualisatie voor", "is dit de juiste grafiek", "what chart should I use", "how to visualize this data". NL + EN.
+---
+
+# Grafiekkeuze (TRIPS-beslisboom)
+
+## Overzicht
+
+Kies precies één grafieksoort via de TRIPS-beslisboom en lever werkende **Plotly**-code.
+Kernprincipe: de juiste grafiek volgt uit **verhaal + publiek + doel + datastructuur** — niet uit gewoonte.
+
+Bron van het beslismodel: TRIPS. Vermeld dat kort bij het advies.
+
+## Werkwijze
+
+1. **Kader (TRIPS 1–3):** weeg kort mee — welk *verhaal* vertel je, aan *wie*, met welk *doel*.
+2. **Afleiden:** bepaal zoveel mogelijk uit de datastructuur en het verzoek (zie `beslisboom.md`).
+3. **Gericht doorvragen:** stel alléén de 1–2 vragen die nú nog beslissend zijn. Loop de boom niet volledig met de gebruiker door.
+4. **Kies + verantwoord:** noem de grafieksoort + het pad door de boom in één regel
+   (bv. *"geen enkel getal → deel van geheel → over tijd → procentueel aandeel → 100% gestapelde kolomdiagram"*).
+5. **Code:** detecteer de stack en lever Plotly:
+   - frontend (HTML/CSS/JS) → `plotly.js`-snippet — zie `templates/plotly-js.md`
+   - Python (notebook / Streamlit / FastAPI) → `plotly.py` — zie `templates/plotly-py.md`
+   - Vul de échte data in waar bekend; anders duidelijk gemarkeerde placeholders.
+   - Standaard een snippet in de chat; schrijf alléén naar een bestand als de gebruiker daarom vraagt.
+   - Noem Chart.js/andere libraries alleen als de gebruiker er expliciet om vraagt.
+
+## Beslisboom — uitkomsten in één oogopslag
+
+| Uitkomst | Wanneer | Plotly-type |
+|---|---|---|
+| Enkel getal | één getal, géén norm/maximum-context | `indicator` (number) |
+| Enkel getal geschaald | één getal t.o.v. norm/maximum | `indicator` (gauge/bullet) |
+| Cirkeldiagram | deel-van-geheel, **één** periode | `pie` |
+| Lijndiagram | trend in de tijd | `scatter` mode lines |
+| Kolomdiagram (verticaal) | vergelijken, ordening op tijd-/getalas | `bar` |
+| Staafdiagram (horizontaal) | vergelijken, veel/lange categorielabels | `bar` `orientation:'h'` |
+| Gestapelde staafdiagram | deel-van-geheel over **categorieën**, absoluut | `bar` h + `barmode:'stack'` |
+| 100% gestapelde staafdiagram | deel-van-geheel over **categorieën**, % aandeel | h + `barmode:'stack'`, genormaliseerd |
+| Gestapelde kolomdiagram | deel-van-geheel over **tijd**, absoluut | `bar` v + `barmode:'stack'` |
+| 100% gestapelde kolomdiagram | deel-van-geheel over **tijd**, % aandeel | v + `barmode:'stack'`, genormaliseerd |
+| Correlatie-analyse | samenhang tussen variabelen | `scatter` mode markers |
+| Lijst/tabel | exacte waarden opzoeken, geen visueel patroon | `table` |
+
+Volledige boom met alle ja/nee-paden: zie `beslisboom.md`.
+
+## Veelgemaakte fouten
+
+- **Tijd vs. categorie door elkaar bij gestapeld/vergelijken:** over **tijd** → **kolom**diagram (verticaal, tijd op x-as); over **categorieën** → **staaf**diagram (horizontaal). Een generieke keuze pakt vaak ten onrechte een staaf voor een tijdreeks.
+- **Hele boom uitvragen** i.p.v. afleiden uit de data en alleen het beslissende restant vragen.
+- **Cirkeldiagram voor meerdere periodes** — cirkel is alléén voor deel-van-geheel in één periode.
+- **Te veel categorieën in cirkel/gestapeld** — bij >5–7 delen wordt het onleesbaar; overweeg staaf of tabel.
+- **Een derde dimensie in één grafiek persen** — een (gestapelde) grafiek toont twee dimensies (bv. cohort × vooropleiding). Komt er een extra groepering bij (bv. per opleiding), maak dan een **facet**: één grafiek per groep, niet alles in één.
+- **Default naar Chart.js** terwijl de rode draad Plotly is.

--- a/.claude/skills/grafiekkeuze/beslisboom.md
+++ b/.claude/skills/grafiekkeuze/beslisboom.md
@@ -1,0 +1,55 @@
+# TRIPS-beslisboom — volledig
+
+Bron: TRIPS-beslismodel "Welke grafiek wanneer". Letterlijk getranscribeerd uit het originele
+schema en bevestigd tegen de bron (incl. de twee eerder dubbelzinnige pijlen, zie onderaan).
+
+## Kadervragen (altijd eerst, kort)
+
+1. **Welk verhaal wil je vertellen?**
+2. **Aan wie vertel je het?**
+3. **Met welk doel?**
+
+Deze drie sturen de toon en detaillering, niet direct de grafieksoort. Neem ze mee in de afweging.
+
+## De boom
+
+```
+4. Wil je één enkel getal inzien?
+├─ JA → 4.a Wil je dit zien in de context van maxima en normen?
+│        ├─ JA  → ENKEL GETAL GESCHAALD (gauge/bullet)
+│        └─ NEE → ENKEL GETAL (groot kengetal, bv. "72%")
+│
+└─ NEE → 5. Wil je weten hoe data deel zijn van een geheel?
+         ├─ JA → 5.a Wil je data uit slechts één periode bekijken?
+         │        ├─ JA  → CIRKELDIAGRAM
+         │        └─ NEE → 5.b Gaat het over tijd of categorieën?
+         │                 ├─ CATEGORIEËN → 5.c Wil je het procentuele aandeel van elk deel weten?
+         │                 │                 ├─ JA  → 100% GESTAPELDE STAAFDIAGRAM (horizontaal)
+         │                 │                 └─ NEE → GESTAPELDE STAAFDIAGRAM (horizontaal)
+         │                 └─ TIJD        → 5.c Wil je het procentuele aandeel van elk deel weten?
+         │                                   ├─ JA  → 100% GESTAPELDE KOLOMDIAGRAM (verticaal)
+         │                                   └─ NEE → GESTAPELDE KOLOMDIAGRAM (verticaal)
+         │
+         └─ NEE → 6. Ben je op zoek naar een trend in tijd?
+                  ├─ JA  → LIJNDIAGRAM
+                  └─ NEE → 7. Wil je meerdere databronnen vergelijken?
+                           ├─ JA  → KOLOMDIAGRAM / STAAFDIAGRAM   (zie ⚠ hieronder)
+                           └─ NEE → 8. Wil je weten in hoeverre data aan elkaar gerelateerd zijn?
+                                    ├─ JA  → CORRELATIE-ANALYSE (scatter)
+                                    └─ NEE → LIJST / TABEL WEERGAVE
+```
+
+## Conventie kolom vs. staaf
+
+Door de hele boom geldt:
+- **Kolomdiagram = verticaal** — gebruikt waar de x-as een **tijd**- of natuurlijke volgorde heeft.
+- **Staafdiagram = horizontaal** — gebruikt voor **categorieën**, zeker bij veel of lange labels.
+
+Bij vraag 7 (vergelijken): kies **kolom** als er een tijd-/ordeningsas is, anders **staaf**
+(horizontaal leest prettiger bij veel of lange categorienamen).
+
+## Bevestigd tegen de bron
+
+1. **Vraag 6 "Ja"** → **Lijndiagram** (trend in tijd → lijn).
+2. **Vraag 7 "Ja"** → **Kolomdiagram óf Staafdiagram** als twee gelijkwaardige opties; kies via de
+   kolom/staaf-conventie hierboven (tijd/ordening → kolom, anders → staaf) en benoem de keuze.

--- a/.claude/skills/grafiekkeuze/templates/plotly-js.md
+++ b/.claude/skills/grafiekkeuze/templates/plotly-js.md
@@ -1,0 +1,123 @@
+# Plotly.js-snippets per uitkomst
+
+Frontend-gebruik. Laad Plotly één keer: `<script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>`
+en render in een container: `<div id="chart"></div>`. Vervang de placeholderdata door echte cijfers.
+Alle voorbeelden gebruiken `{responsive: true}` zodat ze meeschalen in een dashboard.
+
+```js
+const cfg = {responsive: true, displayModeBar: false, locale: 'nl'};
+```
+
+## Enkel getal
+```js
+Plotly.newPlot('chart', [{
+  type: 'indicator', mode: 'number',
+  value: 72, number: {suffix: '%', font: {size: 64}}
+}], {margin: {t: 0, b: 0}}, cfg);
+```
+
+## Enkel getal geschaald (gauge t.o.v. norm/maximum)
+```js
+Plotly.newPlot('chart', [{
+  type: 'indicator', mode: 'gauge+number', value: 72,
+  number: {suffix: '%'},
+  gauge: {axis: {range: [0, 100]}, threshold: {value: 80, line: {color: 'red', width: 3}}}
+}], {margin: {t: 20, b: 0}}, cfg);   // threshold = norm
+```
+
+## Cirkeldiagram (deel-van-geheel, één periode)
+```js
+Plotly.newPlot('chart', [{
+  type: 'pie', labels: ['A', 'B', 'C'], values: [45, 35, 20], hole: 0   // hole>0 = donut
+}], {}, cfg);
+```
+
+## Lijndiagram (trend in tijd)
+```js
+Plotly.newPlot('chart', [{
+  type: 'scatter', mode: 'lines+markers',
+  x: ['2020', '2021', '2022', '2023'], y: [120, 135, 150, 168]
+}], {xaxis: {title: 'Jaar'}, yaxis: {title: 'Aantal'}}, cfg);
+```
+
+## Kolomdiagram (verticaal — vergelijken op tijd-/getalas)
+```js
+Plotly.newPlot('chart', [{
+  type: 'bar', x: ['2020', '2021', '2022'], y: [120, 135, 150]
+}], {yaxis: {title: 'Aantal'}}, cfg);
+```
+
+## Staafdiagram (horizontaal — vergelijken van categorieën)
+```js
+const inst = ['Inst. A', 'Inst. B', 'Inst. C'], score = [7.2, 6.8, 8.1];
+const order = score.map((_, i) => i).sort((a, b) => score[a] - score[b]);   // sorteren = beter leesbaar
+Plotly.newPlot('chart', [{
+  type: 'bar', orientation: 'h',
+  x: order.map(i => score[i]), y: order.map(i => inst[i])
+}], {xaxis: {title: 'Score'}, margin: {l: 120}}, cfg);
+```
+
+## Gestapelde staafdiagram (deel-van-geheel over categorieën, absoluut)
+```js
+const cats = ['Opl. A', 'Opl. B', 'Opl. C'];
+Plotly.newPlot('chart', [
+  {type: 'bar', orientation: 'h', name: 'Vmbo', y: cats, x: [40, 30, 50]},
+  {type: 'bar', orientation: 'h', name: 'Havo', y: cats, x: [25, 35, 20]},
+  {type: 'bar', orientation: 'h', name: 'Mbo',  y: cats, x: [15, 20, 18]}
+], {barmode: 'stack', margin: {l: 100}}, cfg);
+```
+
+## 100% gestapelde staafdiagram (categorieën, procentueel aandeel)
+Normaliseer per categorie naar 100% en toon het absolute getal in de tooltip.
+```js
+const cats = ['Opl. A', 'Opl. B', 'Opl. C'];
+const reeksen = {Vmbo: [40, 30, 50], Havo: [25, 35, 20], Mbo: [15, 20, 18]};
+const totaal = cats.map((_, i) => Object.values(reeksen).reduce((s, r) => s + r[i], 0));
+const data = Object.entries(reeksen).map(([naam, r]) => ({
+  type: 'bar', orientation: 'h', name: naam, y: cats,
+  x: r.map((v, i) => 100 * v / totaal[i]),
+  customdata: r, hovertemplate: '%{y} – ' + naam + ': %{x:.1f}% (%{customdata})<extra></extra>'
+}));
+Plotly.newPlot('chart', data, {barmode: 'stack', xaxis: {ticksuffix: '%', range: [0, 100]}, margin: {l: 100}}, cfg);
+```
+
+## Gestapelde kolomdiagram (deel-van-geheel over tijd, absoluut)
+```js
+const jaren = ['2020', '2021', '2022', '2023'];
+Plotly.newPlot('chart', [
+  {type: 'bar', name: 'Vmbo', x: jaren, y: [40, 42, 45, 48]},
+  {type: 'bar', name: 'Havo', x: jaren, y: [25, 27, 26, 30]},
+  {type: 'bar', name: 'Mbo',  x: jaren, y: [15, 16, 18, 17]}
+], {barmode: 'stack', xaxis: {title: 'Cohort'}}, cfg);
+```
+
+## 100% gestapelde kolomdiagram (over tijd, procentueel aandeel)
+```js
+const jaren = ['2020', '2021', '2022', '2023'];
+const reeksen = {Vmbo: [40, 42, 45, 48], Havo: [25, 27, 26, 30], Mbo: [15, 16, 18, 17]};
+const totaal = jaren.map((_, i) => Object.values(reeksen).reduce((s, r) => s + r[i], 0));
+const data = Object.entries(reeksen).map(([naam, r]) => ({
+  type: 'bar', name: naam, x: jaren,
+  y: r.map((v, i) => 100 * v / totaal[i]),
+  customdata: r, hovertemplate: '%{x} – ' + naam + ': %{y:.1f}% (%{customdata})<extra></extra>'
+}));
+Plotly.newPlot('chart', data, {barmode: 'stack', yaxis: {ticksuffix: '%', range: [0, 100]}, xaxis: {title: 'Cohort'}}, cfg);
+```
+
+## Correlatie-analyse (scatter)
+```js
+Plotly.newPlot('chart', [{
+  type: 'scatter', mode: 'markers',
+  x: [3.1, 4.0, 5.2, 6.1, 7.4], y: [120, 150, 165, 180, 210],
+  marker: {size: 10}
+}], {xaxis: {title: 'Variabele X'}, yaxis: {title: 'Variabele Y'}}, cfg);
+```
+
+## Lijst / tabel
+```js
+Plotly.newPlot('chart', [{
+  type: 'table',
+  header: {values: ['Instelling', 'Score'], fill: {color: '#e8eef5'}, align: 'left'},
+  cells:  {values: [['Inst. A', 'Inst. B', 'Inst. C'], [7.2, 6.8, 8.1]], align: 'left'}
+}], {}, cfg);
+```

--- a/.claude/skills/grafiekkeuze/templates/plotly-py.md
+++ b/.claude/skills/grafiekkeuze/templates/plotly-py.md
@@ -1,0 +1,110 @@
+# plotly.py-snippets per uitkomst
+
+Python-gebruik (notebook / Streamlit / FastAPI). `import plotly.graph_objects as go`
+(en `import plotly.express as px` waar handig). Toon met `fig.show()`, of in Streamlit met
+`st.plotly_chart(fig, use_container_width=True)`. Vervang placeholderdata door echte cijfers.
+
+## Enkel getal
+```python
+import plotly.graph_objects as go
+fig = go.Figure(go.Indicator(mode="number", value=72, number={"suffix": "%"}))
+```
+
+## Enkel getal geschaald (gauge t.o.v. norm/maximum)
+```python
+fig = go.Figure(go.Indicator(
+    mode="gauge+number", value=72, number={"suffix": "%"},
+    gauge={"axis": {"range": [0, 100]},
+           "threshold": {"value": 80, "line": {"color": "red", "width": 3}}}))  # threshold = norm
+```
+
+## Cirkeldiagram (deel-van-geheel, één periode)
+```python
+fig = go.Figure(go.Pie(labels=["A", "B", "C"], values=[45, 35, 20]))  # hole=0.4 voor donut
+```
+
+## Lijndiagram (trend in tijd)
+```python
+fig = go.Figure(go.Scatter(x=["2020", "2021", "2022", "2023"], y=[120, 135, 150, 168],
+                           mode="lines+markers"))
+fig.update_layout(xaxis_title="Jaar", yaxis_title="Aantal")
+```
+
+## Kolomdiagram (verticaal — vergelijken op tijd-/getalas)
+```python
+fig = go.Figure(go.Bar(x=["2020", "2021", "2022"], y=[120, 135, 150]))
+fig.update_layout(yaxis_title="Aantal")
+```
+
+## Staafdiagram (horizontaal — vergelijken van categorieën)
+```python
+inst, score = ["Inst. A", "Inst. B", "Inst. C"], [7.2, 6.8, 8.1]
+paren = sorted(zip(score, inst))                       # sorteren = beter leesbaar
+fig = go.Figure(go.Bar(x=[s for s, _ in paren], y=[i for _, i in paren], orientation="h"))
+fig.update_layout(xaxis_title="Score")
+```
+
+## Gestapelde staafdiagram (deel-van-geheel over categorieën, absoluut)
+```python
+cats = ["Opl. A", "Opl. B", "Opl. C"]
+fig = go.Figure([
+    go.Bar(name="Vmbo", y=cats, x=[40, 30, 50], orientation="h"),
+    go.Bar(name="Havo", y=cats, x=[25, 35, 20], orientation="h"),
+    go.Bar(name="Mbo",  y=cats, x=[15, 20, 18], orientation="h"),
+])
+fig.update_layout(barmode="stack")
+```
+
+## 100% gestapelde staafdiagram (categorieën, procentueel aandeel)
+```python
+cats = ["Opl. A", "Opl. B", "Opl. C"]
+reeksen = {"Vmbo": [40, 30, 50], "Havo": [25, 35, 20], "Mbo": [15, 20, 18]}
+totaal = [sum(r[i] for r in reeksen.values()) for i in range(len(cats))]
+fig = go.Figure([
+    go.Bar(name=naam, y=cats, orientation="h",
+           x=[100 * v / totaal[i] for i, v in enumerate(r)],
+           customdata=r, hovertemplate="%{y} – " + naam + ": %{x:.1f}% (%{customdata})<extra></extra>")
+    for naam, r in reeksen.items()
+])
+fig.update_layout(barmode="stack", xaxis=dict(ticksuffix="%", range=[0, 100]))
+```
+
+## Gestapelde kolomdiagram (deel-van-geheel over tijd, absoluut)
+```python
+jaren = ["2020", "2021", "2022", "2023"]
+fig = go.Figure([
+    go.Bar(name="Vmbo", x=jaren, y=[40, 42, 45, 48]),
+    go.Bar(name="Havo", x=jaren, y=[25, 27, 26, 30]),
+    go.Bar(name="Mbo",  x=jaren, y=[15, 16, 18, 17]),
+])
+fig.update_layout(barmode="stack", xaxis_title="Cohort")
+```
+
+## 100% gestapelde kolomdiagram (over tijd, procentueel aandeel)
+```python
+jaren = ["2020", "2021", "2022", "2023"]
+reeksen = {"Vmbo": [40, 42, 45, 48], "Havo": [25, 27, 26, 30], "Mbo": [15, 16, 18, 17]}
+totaal = [sum(r[i] for r in reeksen.values()) for i in range(len(jaren))]
+fig = go.Figure([
+    go.Bar(name=naam, x=jaren,
+           y=[100 * v / totaal[i] for i, v in enumerate(r)],
+           customdata=r, hovertemplate="%{x} – " + naam + ": %{y:.1f}% (%{customdata})<extra></extra>")
+    for naam, r in reeksen.items()
+])
+fig.update_layout(barmode="stack", yaxis=dict(ticksuffix="%", range=[0, 100]), xaxis_title="Cohort")
+```
+
+## Correlatie-analyse (scatter)
+```python
+fig = go.Figure(go.Scatter(x=[3.1, 4.0, 5.2, 6.1, 7.4], y=[120, 150, 165, 180, 210],
+                           mode="markers", marker=dict(size=10)))
+fig.update_layout(xaxis_title="Variabele X", yaxis_title="Variabele Y")
+```
+
+## Lijst / tabel
+```python
+fig = go.Figure(go.Table(
+    header=dict(values=["Instelling", "Score"], fill_color="#e8eef5", align="left"),
+    cells=dict(values=[["Inst. A", "Inst. B", "Inst. C"], [7.2, 6.8, 8.1]], align="left"),
+))
+```


### PR DESCRIPTION
## Wat
Voegt de **grafiekkeuze**-skill toe aan `.claude/skills/`, zodat het hele team 'm krijgt.

De skill kiest precies één grafieksoort via de **TRIPS-beslisboom** en levert werkende **Plotly**-code (js óf py, afhankelijk van de stack).

## Inhoud
- `SKILL.md` — werkwijze + beslisboom-overzicht in één tabel
- `beslisboom.md` — volledige ja/nee-paden
- `templates/plotly-js.md` + `templates/plotly-py.md` — kant-en-klare snippets

## Triggers
"welke grafiek/diagram", "hoe visualiseer ik deze data", "maak een grafiek voor…", "what chart should I use" (NL + EN).

Ed de Feber, in nauwe samenwerking met Claude