### PR TITLE
feat: add CEDA/SDP platform skills (gitlab-ci, sdp-onboard, surf-sdp-helm-flux, sdp-secrets-management)

### DIFF
--- a/.claude/skills/gitlab-ci/SKILL.md
+++ b/.claude/skills/gitlab-ci/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: gitlab-ci
+description: Author and debug GitLab CI for the CEDA/SURF config repos (*-config) — the SDP shared components, the branch→cluster rules, Helm package/publish/promote, and kubernetes diff/dry-run/verify stages. Use when editing .gitlab-ci.yml, a .gitlab/*.yaml component, or debugging a GitLab pipeline in a config repo.
+---
+
+# gitlab-ci
+
+The `*-config` GitOps repos (`instroom-config`, `1cijfer-config`, …) deploy via
+**GitLab CI built on SURF's shared SDP components**. This is a different world
+from the GitHub Actions repos (see [[actions-ci]]).
+
+## Branch → cluster mapping (workflow.rules)
+`.gitlab-ci.yml` sets `ENVIRONMENT_CLUSTER` from the trigger:
+- **Merge request** (`$CI_MERGE_REQUEST_IID`) → `development`
+- default branch or `pipeline` branch → `testing`
+- pipeline trigger / `test/trigger` → `testing`
+- **tag** (`$CI_COMMIT_TAG`) → `playground`
+
+When changing where something deploys, edit these `workflow.rules`, not scattered
+job rules. Be explicit about which cluster a change targets.
+
+## SDP shared components (don't reinvent)
+Pipelines `include:` versioned components from
+`$CI_SERVER_FQDN/surf-internal/sdp/components/...`:
+- `base/base`, `base/security`
+- `semver/generate-version`, `semver/promote-version`
+- `helm/helm-lint`, `helm/helm-publish`, `helm/helm-promote`
+- `kubernetes/diff`, `kubernetes/dry-run`, `kubernetes/verify-up`, `kubernetes/deploy-preview`
+Plus the repo-local `.gitlab/helm-package.yaml` (a `spec.inputs` component that
+patches the docker image ref + chart version, then `helm package`).
+Prefer wiring an existing SDP component over writing bespoke job YAML.
+
+## The deploy flow
+package → publish (to Harbor OCI: `oci://$HARBOR_HOST/...`) → promote →
+`kubernetes/diff` → `dry-run` → `verify-up`. The pipeline itself runs the
+diff/dry-run/verify against `${ENVIRONMENT_CLUSTER}` — so review the **diff and
+dry-run** output in the pipeline before a change reaches a real cluster. Don't
+run `kubectl apply`/`helm upgrade` by hand.
+
+## Chart / values layout
+`charts/<app>/` + `manifests/<env>/values.yaml` over `manifests/base/values-base.yaml`.
+See [[surf-sdp-helm-flux]] for the full layout and SOPS secret handling.
+
+## Local component structure (authoring)
+Repo-local components live in `.gitlab/*.yaml` with a `spec: inputs:` header
+(typed inputs w/ defaults) then `---` then the job body using `$[[ inputs.x ]]`.
+Match that shape when adding one.
+
+## Debugging
+- Use `glab` (GitLab CLI) or the GitLab web UI for MRs/pipelines — **not** `gh`.
+- Read pipeline logs before retrying; avoid guess-and-check (see the principle of verifying work actually runs before calling it done).
+- Secrets are SOPS-encrypted (`.sops.yaml`); never print or commit plaintext.
+
+## Reference
+See the CEDA repo split (GitLab *-config repos vs GitHub app repos) for which repos are GitLab-config vs GitHub-app.

--- a/.claude/skills/gitlab-ci/SKILL.md
+++ b/.claude/skills/gitlab-ci/SKILL.md
@@ -7,7 +7,15 @@ description: Author and debug GitLab CI for the CEDA/SURF config repos (*-config
 
 The `*-config` GitOps repos (`instroom-config`, `1cijfer-config`, …) deploy via
 **GitLab CI built on SURF's shared SDP components**. This is a different world
-from the GitHub Actions repos (see [[actions-ci]]).
+from the GitHub Actions repos (see /actions-ci).
+
+## When this applies
+
+This is a **knowledge skill** — it loads (explicitly via `/gitlab-ci`, or
+automatically) when you edit a `.gitlab-ci.yml`, a `.gitlab/*.yaml` component, or
+debug a GitLab pipeline in a `*-config` repo. It is reference/convention, not a
+step-by-step procedure. For deploy/Flux troubleshooting see /surf-sdp-helm-flux;
+for GitHub repos see /actions-ci.
 
 ## Branch → cluster mapping (workflow.rules)
 `.gitlab-ci.yml` sets `ENVIRONMENT_CLUSTER` from the trigger:
@@ -39,7 +47,7 @@ run `kubectl apply`/`helm upgrade` by hand.
 
 ## Chart / values layout
 `charts/<app>/` + `manifests/<env>/values.yaml` over `manifests/base/values-base.yaml`.
-See [[surf-sdp-helm-flux]] for the full layout and SOPS secret handling.
+See /surf-sdp-helm-flux for the full layout and SOPS secret handling.
 
 ## Local component structure (authoring)
 Repo-local components live in `.gitlab/*.yaml` with a `spec: inputs:` header
@@ -48,8 +56,14 @@ Match that shape when adding one.
 
 ## Debugging
 - Use `glab` (GitLab CLI) or the GitLab web UI for MRs/pipelines — **not** `gh`.
-- Read pipeline logs before retrying; avoid guess-and-check (see the principle of verifying work actually runs before calling it done).
+- Read pipeline logs before retrying; avoid guess-and-check loops.
 - Secrets are SOPS-encrypted (`.sops.yaml`); never print or commit plaintext.
 
-## Reference
-See the CEDA repo split (GitLab *-config repos vs GitHub app repos) for which repos are GitLab-config vs GitHub-app.
+## Important
+- These are **GitLab** repos — use `glab`/the web UI, never `gh` or GitHub-Actions
+  patterns (those live in /actions-ci).
+- **Prefer wiring an existing SDP shared component** over writing bespoke job YAML.
+- Deploys run through the pipeline (diff → dry-run → verify) — this skill does NOT
+  run `kubectl apply`/`helm upgrade` by hand.
+- Secrets stay SOPS-encrypted; never print or commit plaintext (see /sdp-secrets-management).
+- Applies to cedanl `*-config` repos on GitLab.

--- a/.claude/skills/sdp-onboard/SKILL.md
+++ b/.claude/skills/sdp-onboard/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: sdp-onboard
+description: Take a CEDA app from code to a running Kubernetes deployment on SURF's SDP — obtain access, create the GitLab repo (Terraform in gitlab-config), request a tenant, copy the GitLab scaffolding from a template repo, and wire up per-env manifests/URLs. Use when standing up a NEW CEDA/SDP service or onboarding a repo to the SURF Developer Platform.
+---
+
+# sdp-onboard
+
+End-to-end path to get a CEDA app running on the **SURF Developer Platform (SDP)**,
+distilled from the CEDA runbook (`text-analysis/docs/{access,gitlab,streamlit-setup}.md`
+in that repo — read the current version there for full detail).
+Several steps need **SDP-admin approval** — flag those; you can't self-merge them.
+
+## Prereqs / access (docs/access.md)
+- SURF account (`@surf.nl`), on the **SURF VPN (eduVPN)**.
+- GitLab is `https://git.ia.surfsara.nl/surf-internal/npuls/ceda/` — **not** github.com.
+- SSH: Ed25519 key (`ssh-keygen -t ed25519`), add pubkey to GitLab (Authentication & Signing).
+- Tools: `brew install hadolint yamllint k9s kubectl kubectx kubelogin kustomize helm flux sops`.
+
+## 1. Create the GitLab repo (needs SDP-admin merge)
+The repo is declared as **Terraform** in the `surf-internal/gitlab-config` repo:
+```bash
+git clone git@git.ia.surfsara.nl:surf-internal/gitlab-config.git
+cd gitlab-config && git checkout -b create_repository_ceda_<app>
+# edit terraform/npuls/ceda/main.tf — add a module block:
+```
+```tf
+module "<app>" {
+  source = "../../modules/project"
+  name = "CEDA <App>"
+  path = "<app>"
+  description = "..."
+  namespace_id = var.parent_group_id
+  visibility_level = "internal"
+  topics = ["npuls", "ceda", "<app>"]
+  container_cleanup_enabled = false
+  group_ids_to_grant_access = { (var.teams_id_map["ceda-team"]) = "maintainer" }
+  invite_admin_role_urn = var.teams_invite_admin_role_urn_map["ceda-team"]
+  invite_dev_role_urn   = var.teams_invite_dev_role_urn_map["ceda-team"]
+}
+```
+Module name: letter/underscore start; letters, digits, `_`, `-` only. Push, open
+an MR, assign an **SDP-team reviewer** to merge (ping via Element/Backstage).
+
+## 2. Request a tenant (needs SDP-admin action)
+Gets you the SDP environments to run in. Use the Backstage "Requesting a tenant"
+form: Department `NPULS - CEDA`, Service phase `Pilot/PoC`, Sizing `S`,
+Kafka/MinIO/PostgreSQL as needed, the GitLab repo URL, Internal access `Yes`.
+Infra tweaks (e.g. Ingress port propagation, which environments) may need an MR to
+`surf-internal/sdp/infrastructure/kubernetes-clusters`.
+
+## 3. Point your code at the new repo
+```bash
+git remote set-url origin git@git.ia.surfsara.nl:surf-internal/npuls/ceda/<app>.git
+```
+(The runbook has a full rebase dance to start `main` clean when migrating from a
+GitHub repo — follow docs/streamlit-setup.md carefully; don't improvise a
+`reset --hard` without reading it.)
+
+## 4. Copy GitLab scaffolding from a template repo
+Pull the deployment machinery from an existing repo (e.g. `text-analysis`) and rename:
+```bash
+GITLAB_FILES="requirements.txt manifests Dockerfile docker-compose.yml charts .gitlab-ci.yml .gitlab"
+git fetch <template-remote> HEAD:<branch>
+git checkout <branch> -- $GITLAB_FILES
+find $GITLAB_FILES -type f | xargs perl -pi -e 's/text-analysis/<app>/g'
+git mv charts/text-analysis charts/<app>   # Chart.yaml name field is manual
+```
+`python-fastapi-template` is the from-scratch SDP starting template.
+
+## 5. Wire up environments (GitLab web UI)
+For each of development/testing/staging/playground, in **Operate → Environments → edit**:
+```
+External URL: https://<app>.<env>.sdp.surf.nl   (dev uses .dev., test uses .test.)
+GitLab agent: <env>
+Kubernetes namespace: services-<app>
+Flux resource: <app>
+```
+(Note: this is web-UI-only — there is currently no code-based way to set it.)
+
+## Deploy model: Flux + Kustomize (corrects plain-Helm assumptions)
+`manifests/base/` holds Flux `helmrelease.yaml` + `helmrepo.yaml` +
+`kustomization.yaml` + `values-base.yaml`; each env dir has a `kustomization.yaml`
+that patches base with its `values.yaml`. **Flux** syncs; deploy = commit + MR
+triggering the GitLab pipeline. See [[gitlab-ci]], [[surf-sdp-helm-flux]], [[sdp-secrets-management]].
+
+## Cluster access & inspection (read-only)
+```bash
+kubectx <env>                                            # development/testing/...
+kubectl config set-context --current --namespace=services-<app>   # once per context
+kubectl -n services-<app> get pod,ep,svc,ing,deployment
+kubectl logs <pod> -n services-<app>
+```
+Health probes hit `/healthz`. Never mutate a cluster by hand — deploys go via CI.
+
+## Honesty
+Steps 1–2 depend on SDP admins; say so and don't claim "done" until merged/granted.
+The template-copy rename is mechanical — verify `grep -ri <template-name>` comes back
+clean (except Chart.yaml). See the principle of verifying work actually runs before calling it done.

--- a/.claude/skills/sdp-onboard/SKILL.md
+++ b/.claude/skills/sdp-onboard/SKILL.md
@@ -10,6 +10,11 @@ distilled from the CEDA runbook (`text-analysis/docs/{access,gitlab,streamlit-se
 in that repo — read the current version there for full detail).
 Several steps need **SDP-admin approval** — flag those; you can't self-merge them.
 
+## Workflow
+
+When the user invokes `/sdp-onboard [optional: app name]`, walk these steps in
+order (prereqs first):
+
 ## Prereqs / access (docs/access.md)
 - SURF account (`@surf.nl`), on the **SURF VPN (eduVPN)**.
 - GitLab is `https://git.ia.surfsara.nl/surf-internal/npuls/ceda/` — **not** github.com.
@@ -81,7 +86,7 @@ Flux resource: <app>
 `manifests/base/` holds Flux `helmrelease.yaml` + `helmrepo.yaml` +
 `kustomization.yaml` + `values-base.yaml`; each env dir has a `kustomization.yaml`
 that patches base with its `values.yaml`. **Flux** syncs; deploy = commit + MR
-triggering the GitLab pipeline. See [[gitlab-ci]], [[surf-sdp-helm-flux]], [[sdp-secrets-management]].
+triggering the GitLab pipeline. See /gitlab-ci, /surf-sdp-helm-flux, /sdp-secrets-management.
 
 ## Cluster access & inspection (read-only)
 ```bash
@@ -92,7 +97,12 @@ kubectl logs <pod> -n services-<app>
 ```
 Health probes hit `/healthz`. Never mutate a cluster by hand — deploys go via CI.
 
-## Honesty
-Steps 1–2 depend on SDP admins; say so and don't claim "done" until merged/granted.
-The template-copy rename is mechanical — verify `grep -ri <template-name>` comes back
-clean (except Chart.yaml). See the principle of verifying work actually runs before calling it done.
+## Important
+- **Steps 1–2 depend on SDP admins** (repo creation MR + tenant request) — flag
+  this and don't claim "done" until merged/granted; you can't self-merge them.
+- **Never mutate a cluster by hand** — deploys go via GitLab CI / Flux
+  (see /gitlab-ci, /surf-sdp-helm-flux).
+- After the template-copy rename, verify `grep -ri <template-name>` comes back
+  clean (except `Chart.yaml`, which is edited manually).
+- These are **GitLab** repos — use `glab`/the web UI, not `gh`.
+- Applies to cedanl / SURF SDP repos.

--- a/.claude/skills/sdp-onboard/SKILL.md
+++ b/.claude/skills/sdp-onboard/SKILL.md
@@ -19,7 +19,9 @@ order (prereqs first):
 - SURF account (`@surf.nl`), on the **SURF VPN (eduVPN)**.
 - GitLab is `https://git.ia.surfsara.nl/surf-internal/npuls/ceda/` — **not** github.com.
 - SSH: Ed25519 key (`ssh-keygen -t ed25519`), add pubkey to GitLab (Authentication & Signing).
-- Tools: `brew install hadolint yamllint k9s kubectl kubectx kubelogin kustomize helm flux sops`.
+- Tools (install via your OS package manager — `brew` on macOS, or the Linux
+  equivalent): `hadolint`, `yamllint`, `k9s`, `kubectl`, `kubectx`, `kubelogin`,
+  `kustomize`, `helm`, `flux`, `sops`.
 
 ## 1. Create the GitLab repo (needs SDP-admin merge)
 The repo is declared as **Terraform** in the `surf-internal/gitlab-config` repo:
@@ -62,13 +64,17 @@ GitHub repo — follow docs/streamlit-setup.md carefully; don't improvise a
 `reset --hard` without reading it.)
 
 ## 4. Copy GitLab scaffolding from a template repo
-Pull the deployment machinery from an existing repo (e.g. `text-analysis`) and rename:
+Pull the deployment machinery from an existing repo and rename. **`1cijfer-ho` is
+the most complete example** — it has all five environments (test, development,
+playground, staging, production), a `manifests/base/kustomizeconfig.yaml` with
+`nameReference`, and full CI wiring all the SDP components. Prefer it over a
+lighter repo:
 ```bash
 GITLAB_FILES="requirements.txt manifests Dockerfile docker-compose.yml charts .gitlab-ci.yml .gitlab"
-git fetch <template-remote> HEAD:<branch>
+git fetch <template-remote> HEAD:<branch>       # e.g. the 1cijfer-ho repo
 git checkout <branch> -- $GITLAB_FILES
-find $GITLAB_FILES -type f | xargs perl -pi -e 's/text-analysis/<app>/g'
-git mv charts/text-analysis charts/<app>   # Chart.yaml name field is manual
+find $GITLAB_FILES -type f | xargs perl -pi -e 's/1cijfer-ho/<app>/g'
+git mv charts/1cijfer-ho charts/<app>           # Chart.yaml name field is manual
 ```
 `python-fastapi-template` is the from-scratch SDP starting template.
 

--- a/.claude/skills/sdp-secrets-management/SKILL.md
+++ b/.claude/skills/sdp-secrets-management/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: sdp-secrets-management
+description: >-
+  Secrets handling conventions for SURF SDP projects: SOPS + AGE encrypted
+  Kubernetes secrets in Git (instroom-config style), .sops.yaml creation
+  rules, key management for teams, GitLab CI integration, and the decision
+  tree for when to use Ansible Vault, SOPS+AGE, or a secret server
+  (OpenBao/Infisical). Use this skill whenever the user encrypts or decrypts
+  secrets, edits a *.secret.yaml or secret_orig.yaml file, hits SOPS errors
+  ("no identity matched", "sops metadata not found", "no matching creation
+  rules"), rotates or adds AGE keys, asks where to store a credential, or
+  mentions sops, age, .sops.yaml, ansible-vault vs alternatives — even if
+  they only paste a SOPS error without a question.
+---
+
+# SDP Secrets Management (SOPS + AGE)
+
+Secrets for SDP Kubernetes deployments are **encrypted in Git** with SOPS
+using AGE keys. No secret server is involved in the standard flow. Follow
+these conventions; read `references/sops-errors.md` for the full error
+catalogue before improvising fixes.
+
+## Which tool for which secret — decision tree
+
+- Secret used **only by Ansible** → Ansible Vault (see the
+  surf-ansible-conventions skill). Zero extra infrastructure.
+- Secret consumed by **k8s manifests, GitLab CI, and/or multiple tools**,
+  encrypted-at-rest-in-Git acceptable → **SOPS + AGE** (this skill's
+  default; works in air-gapped environments).
+- Need runtime injection, rotation, per-secret audit/RBAC → a secret
+  server (OpenBao or self-hosted Infisical, optionally with External
+  Secrets Operator syncing into k8s). Heavier to operate — propose it only
+  when SOPS demonstrably falls short, not by default.
+- CSI driver and ESO are *integration layers*, not stores — they still
+  need a backend and don't compete with SOPS.
+
+## Repository conventions
+
+```
+<config-repo>/
+├── .sops.yaml                    # creation rules, repo root
+└── manifests/
+    └── <env>/
+        ├── secret_orig.yaml      # plaintext working copy — NEVER commit
+        └── secret.yaml           # SOPS-encrypted, committed
+```
+
+`.sops.yaml` at the repo root:
+
+```yaml
+creation_rules:
+  - path_regex: manifests/.*/secret.*\.yaml$
+    encrypted_regex: ^(data|stringData)$
+    age: <age-public-key>[,<second-recipient>,...]
+```
+
+Rules that matter:
+
+- **`path_regex` is a regex, not a glob.** `manifests/*/...` does not mean
+  "any subdirectory" — it means "zero or more `/` characters". Write
+  `manifests/.*/` and test against the real filename; "no matching
+  creation rules found" is almost always this.
+- `encrypted_regex: ^(data|stringData)$` encrypts only the secret payload
+  of a k8s Secret, leaving `kind`/`metadata` readable — keep it that way
+  so diffs and code review stay possible.
+- The `*_orig.yaml` plaintext working copies must be in `.gitignore`.
+  Encrypt to the committed name:
+  `sops --encrypt manifests/dev/secret_orig.yaml > manifests/dev/secret.yaml`
+- When operating from a subdirectory, pass the config explicitly:
+  `sops --config ../../.sops.yaml ...` (note: the flag is `--config`, not
+  `-a`).
+
+## Retrieve an existing value from a cluster (to reuse in a secret)
+
+Often a value you need to put in `secret_orig.yaml` already lives in the
+cluster (e.g. a MinIO admin key created by another chart). Pull and decode it:
+
+```bash
+kubectx <env>                                  # per-env cluster context
+kubectl get secret -n <namespace>              # list; find the one you need
+kubectl get secret -o yaml -n <ns> <name>      # values are base64-encoded
+echo <base64-value> | base64 -d                # decode
+```
+
+Treat the decoded output as sensitive — don't paste it into commits or logs.
+To inspect an already-encrypted repo file without editing: `sops -d <file>`.
+
+## Key management
+
+- Generate: `age-keygen -o ~/.config/sops/age/keys.txt` — the file holds
+  the private key; the public key (`age1...`) goes into `.sops.yaml`.
+- SOPS finds the private key via `SOPS_AGE_KEY_FILE`
+  (`~/.config/sops/age/keys.txt` is the conventional path — export it in
+  your shell profile) or `SOPS_AGE_KEY` (the key string itself; this is
+  the form used as a masked GitLab CI variable).
+- **Team access = multiple recipients.** List every teammate's public key
+  comma-separated in the `age:` field. Files must be **re-keyed** after
+  changing recipients — editing `.sops.yaml` alone changes nothing for
+  existing files: `sops updatekeys manifests/dev/secret.yaml` (or
+  `scripts/rekey-all.sh` for the whole repo).
+- Losing all private keys means the secrets are gone. At least two
+  recipients per repo, always.
+
+## GitLab CI integration
+
+- Store the private key as a masked, protected CI/CD variable
+  `SOPS_AGE_KEY` (variable type, not file — SOPS reads it directly).
+- Decrypt in the job just-in-time; never write plaintext to an artifact:
+
+```yaml
+deploy:
+  script:
+    - sops --decrypt manifests/$ENV/secret.yaml | kubectl apply -f -
+```
+
+- For Flux-managed environments, prefer letting **Flux decrypt in-cluster**
+  instead of the pipeline: store the age private key as a k8s secret
+  (`sops-age`) in the tenant namespace and set
+  `spec.decryption: {provider: sops, secretRef: {name: sops-age}}` on the
+  Kustomization. Then the pipeline never handles plaintext at all.
+
+## Error quick reference
+
+| Error | Meaning | Fix |
+|---|---|---|
+| `no identity matched any of the recipients` | private key for the file's recipient not available | set `SOPS_AGE_KEY_FILE`; check you're a recipient; ask a recipient to `updatekeys` after adding you |
+| `sops metadata not found` | file is plaintext, you used edit/decrypt | encrypt it first (`sops -e`), or you grabbed the `_orig` file |
+| `no matching creation rules found` | `path_regex` doesn't match the path | fix the regex (glob vs regex trap); test with `sops filestatus` |
+| Encrypted file has plaintext fields | `encrypted_regex` too narrow, or file edited outside sops | re-encrypt; only edit via `sops <file>` |
+| CI decrypt works locally, fails in job | `SOPS_AGE_KEY` unset/unprotected branch | check variable scope + protected flag |
+
+Full diagnostic walk-throughs: `references/sops-errors.md`.
+
+## Bundled scripts
+
+- `scripts/sops-doctor.sh [file]` — checks key setup (env vars, key file,
+  recipient match) and optionally test-decrypts a file.
+- `scripts/rekey-all.sh <path-regex-root>` — runs `sops updatekeys` over
+  all encrypted files after a recipient change in `.sops.yaml`.

--- a/.claude/skills/sdp-secrets-management/SKILL.md
+++ b/.claude/skills/sdp-secrets-management/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: sdp-secrets-management
 description: >-
-  Secrets handling conventions for SURF SDP projects: SOPS + AGE encrypted
-  Kubernetes secrets in Git (instroom-config style), .sops.yaml creation
+  Manage SOPS + AGE encrypted Kubernetes secrets for SURF SDP projects
+  (instroom-config style): .sops.yaml creation
   rules, key management for teams, GitLab CI integration, and the decision
   tree for when to use Ansible Vault, SOPS+AGE, or a secret server
   (OpenBao/Infisical). Use this skill whenever the user encrypts or decrypts
@@ -19,6 +19,13 @@ Secrets for SDP Kubernetes deployments are **encrypted in Git** with SOPS
 using AGE keys. No secret server is involved in the standard flow. Follow
 these conventions; read `references/sops-errors.md` for the full error
 catalogue before improvising fixes.
+
+## When this applies
+
+This is a **knowledge skill** — it loads (explicitly via `/sdp-secrets-management`,
+or automatically) when you encrypt/decrypt a secret, edit a `*.secret.yaml` /
+`secret_orig.yaml`, hit a SOPS error, rotate/add AGE keys, or ask where a
+credential should live. It is reference + a decision tree, not a procedure to run.
 
 ## Which tool for which secret — decision tree
 
@@ -137,3 +144,15 @@ Full diagnostic walk-throughs: `references/sops-errors.md`.
   recipient match) and optionally test-decrypts a file.
 - `scripts/rekey-all.sh <path-regex-root>` — runs `sops updatekeys` over
   all encrypted files after a recipient change in `.sops.yaml`.
+
+## Important
+- **Never commit plaintext secrets.** Only `secret.yaml` (encrypted) is committed;
+  `*_orig.yaml` plaintext working copies must be gitignored — stage by name.
+- **Never print decrypted values** in a way that persists (logs, artifacts, chat).
+- **Re-key after changing recipients** — editing `.sops.yaml` alone changes
+  nothing for existing files (`sops updatekeys` / `scripts/rekey-all.sh`).
+- Keep **≥2 recipients per repo** — losing all private keys means the secrets are
+  gone.
+- Prefer SOPS+AGE; propose a secret server only when SOPS demonstrably falls short,
+  not by default.
+- Applies to cedanl / SURF SDP repos.

--- a/.claude/skills/sdp-secrets-management/references/sops-errors.md
+++ b/.claude/skills/sdp-secrets-management/references/sops-errors.md
@@ -1,0 +1,95 @@
+# SOPS error catalogue — detailed walk-throughs
+
+## "Failed to get the data key ... no identity matched any of the recipients"
+
+SOPS knows which public key(s) the file was encrypted for (listed in the
+error and in the file's `sops.age` metadata block), but can't find a
+matching private key.
+
+1. Which recipients can decrypt this file?
+   ```bash
+   grep -A2 'recipient:' secret.yaml
+   ```
+2. Where is your private key, and does SOPS know?
+   ```bash
+   ls ~/.config/sops/age/keys.txt
+   echo "$SOPS_AGE_KEY_FILE"; echo "${SOPS_AGE_KEY:+set}"
+   export SOPS_AGE_KEY_FILE=~/.config/sops/age/keys.txt
+   ```
+3. Does your public key match a recipient?
+   ```bash
+   grep 'public key' ~/.config/sops/age/keys.txt
+   ```
+   If your key is *not* among the file's recipients: add your public key
+   to `.sops.yaml` and have someone who **can** decrypt run
+   `sops updatekeys` on the file(s). You cannot grant yourself access.
+
+## "sops metadata not found"
+
+The file is plain YAML — no `sops:` block at the bottom
+(`tail -20 <file>` to confirm). Causes:
+
+- You targeted the `_orig` plaintext working copy.
+- The file was committed unencrypted (incident! rotate the secret, not
+  just the file).
+- You want first-time encryption: `sops -e -i <file>` or
+  `sops -e <orig> > <target>`.
+
+## "error loading config: no matching creation rules found"
+
+The file's path doesn't match any `path_regex` in the `.sops.yaml` in
+effect.
+
+- `path_regex` is a **regex**: `manifests/*/x` means "manifest" + zero or
+  more slashes — not a glob. Use `manifests/.*/secret.*\.yaml$`.
+- The path is matched relative to the `.sops.yaml` location; when running
+  from a subdirectory with `--config`, check what the relative path
+  resolves to.
+- Confirm which config SOPS uses — it searches upward from the target
+  file for `.sops.yaml`. An unexpected nested `.sops.yaml` shadows the
+  root one.
+- Quick test: temporarily broaden to `path_regex: .*\.yaml$`; if that
+  matches, the pattern is the problem, not the config discovery.
+
+## Editing and verifying
+
+- Always edit via `sops <file>` (decrypt→$EDITOR→re-encrypt). Editing the
+  encrypted file directly corrupts the MAC.
+- Show recipients and key groups: `sops --show-master-keys <file>` (older
+  syntax) or inspect the `sops:` metadata block.
+- Verify what is and isn't encrypted after changing `encrypted_regex`:
+  `grep -c 'ENC\[' <file>` and eyeball the non-payload fields.
+
+## Flux in-cluster decryption
+
+Store the age private key in the tenant namespace:
+
+```bash
+kubectl create secret generic sops-age \
+  --namespace <tenant> \
+  --from-file=age.agekey=/path/to/keys.txt
+```
+
+Kustomization spec:
+
+```yaml
+spec:
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+```
+
+Symptoms of a broken setup: Kustomization events show
+`decryption secret error` (secret missing/wrong key name — the data key
+must end in `.agekey`) or the same "no identity matched" text as local
+SOPS (wrong private key for the recipients).
+
+## Incident: plaintext secret committed
+
+1. Rotate the actual credential immediately — history rewriting is
+   secondary, the secret must be assumed leaked.
+2. Encrypt the corrected value properly; add the `_orig` name to
+   `.gitignore`.
+3. Only then consider `git filter-repo` if policy requires history
+   cleanup.

--- a/.claude/skills/sdp-secrets-management/scripts/rekey-all.sh
+++ b/.claude/skills/sdp-secrets-management/scripts/rekey-all.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Re-key all SOPS-encrypted files after changing recipients in .sops.yaml.
+# Run from the repo root (where .sops.yaml lives).
+# Usage: rekey-all.sh [search-root]   (default: manifests/)
+set -euo pipefail
+
+ROOT="${1:-manifests}"
+[ -f .sops.yaml ] || { echo "No .sops.yaml in $(pwd) — run from repo root" >&2; exit 1; }
+
+FOUND=0
+while IFS= read -r -d '' f; do
+  if grep -q 'ENC\[' "$f" || grep -q '^sops:' "$f"; then
+    FOUND=1
+    echo ">> sops updatekeys $f"
+    sops updatekeys --yes "$f"
+  fi
+done < <(find "$ROOT" -name '*.yaml' -print0)
+
+[ "$FOUND" -eq 1 ] || echo "No encrypted files found under ${ROOT}/"
+echo "Done. Remember: new recipients can only decrypt after this ran and was pushed."

--- a/.claude/skills/sdp-secrets-management/scripts/sops-doctor.sh
+++ b/.claude/skills/sdp-secrets-management/scripts/sops-doctor.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Diagnose local SOPS+AGE setup, optionally test-decrypt a file.
+# Usage: sops-doctor.sh [encrypted-file]
+set -uo pipefail
+
+ok()   { printf 'OK    %s\n' "$1"; }
+warn() { printf 'WARN  %s\n' "$1"; }
+fail() { printf 'FAIL  %s\n' "$1"; }
+
+command -v sops >/dev/null && ok "sops installed: $(sops --version 2>/dev/null | head -1)" || fail "sops not in PATH"
+command -v age-keygen >/dev/null && ok "age installed" || warn "age-keygen not in PATH (only needed for key generation)"
+
+KEYFILE="${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/age/keys.txt}"
+if [ -n "${SOPS_AGE_KEY:-}" ]; then
+  ok "SOPS_AGE_KEY is set (using in-env private key)"
+elif [ -f "$KEYFILE" ]; then
+  ok "key file present: $KEYFILE"
+  grep -h 'public key' "$KEYFILE" | sed 's/^# /      my /'
+else
+  fail "no private key: SOPS_AGE_KEY unset and $KEYFILE missing"
+fi
+
+if [ $# -ge 1 ]; then
+  FILE="$1"
+  echo "--- checking ${FILE} ---"
+  if ! grep -q '^sops:' "$FILE" && ! grep -q '"sops":' "$FILE"; then
+    fail "no sops metadata — file is PLAINTEXT (or an _orig working copy)"
+    exit 1
+  fi
+  echo "recipients:"
+  grep -o 'age1[a-z0-9]*' "$FILE" | sort -u | sed 's/^/      /'
+  if sops --decrypt "$FILE" >/dev/null 2>&1; then
+    ok "test decrypt succeeded"
+  else
+    fail "test decrypt failed — your key is not among the recipients, or key not found"
+    echo "      -> ask an existing recipient to add your public key to .sops.yaml"
+    echo "         and run 'sops updatekeys' (see references/sops-errors.md)"
+    exit 1
+  fi
+fi

--- a/.claude/skills/surf-sdp-helm-flux/SKILL.md
+++ b/.claude/skills/surf-sdp-helm-flux/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: surf-sdp-helm-flux
 description: >-
-  Conventions and troubleshooting for Helm/Flux deployments on the SURF SDP
-  platform (GitLab CI → OCI chart in Harbor cr.surf.nl → FluxCD HelmRelease).
+  Deploy and troubleshoot Helm/Flux workloads on the SURF SDP platform
+  (GitLab CI → OCI chart in Harbor cr.surf.nl → FluxCD HelmRelease).
   Use this skill whenever the user works on GitLab CI pipelines that package
   or deploy Helm charts, debugs a failing or stuck HelmRelease, sees Flux
   reconciliation problems, hits 401/404 errors pulling charts from an OCI
@@ -18,6 +18,14 @@ How deployments work on the SURF SDP (Kubernetes) platform, and how to
 diagnose them when they don't. Read this fully before proposing fixes to a
 pipeline log or Flux error someone pastes — most failures here are known
 patterns with known one-line fixes, and generic Helm/Flux advice wastes time.
+
+## When this applies
+
+This is a **knowledge skill** — it loads (explicitly via `/surf-sdp-helm-flux`,
+or automatically) whenever you work on GitLab CI that packages/deploys Helm
+charts, debug a stuck/failing HelmRelease, hit 401/404 pulling charts from
+Harbor OCI, see Flux reconciliation problems, or paste a pipeline log / kubectl
+output. It is reference + troubleshooting, not a procedure to run.
 
 ## Repo layout & local preview
 
@@ -226,3 +234,14 @@ suspend/resume, checking Kustomization sync, job log retrieval), read
 - `scripts/hr-status.sh <helmrelease> <namespace>` — one-shot health
   summary: HelmRelease conditions, history, HelmRepository status, recent
   jobs in the namespace.
+
+## Important
+- **The pipeline never runs `helm upgrade` directly** — it pushes a chart and
+  waits for Flux. Classify a "deploy problem" as (a) chart not published,
+  (b) Flux can't fetch it, or (c) release fails — before acting.
+- **Don't hand-edit Flux resources** (HelmRepository/HelmRelease) in-cluster —
+  the next sync reverts them; fix the source repo instead.
+- Check the `+`↔`_` OCI-tag spelling before assuming a chart is missing.
+- Deploy by **image digest**, not floating tags.
+- This is a **GitLab/SDP** skill — use `glab`/kubectl, not `gh` or GitHub Actions.
+- Applies to cedanl / SURF SDP repos.

--- a/.claude/skills/surf-sdp-helm-flux/SKILL.md
+++ b/.claude/skills/surf-sdp-helm-flux/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: surf-sdp-helm-flux
+description: >-
+  Conventions and troubleshooting for Helm/Flux deployments on the SURF SDP
+  platform (GitLab CI → OCI chart in Harbor cr.surf.nl → FluxCD HelmRelease).
+  Use this skill whenever the user works on GitLab CI pipelines that package
+  or deploy Helm charts, debugs a failing or stuck HelmRelease, sees Flux
+  reconciliation problems, hits 401/404 errors pulling charts from an OCI
+  registry, encounters chart version mismatches in deploy verification, sets
+  up cross-pipeline triggers, or mentions SDP, Harbor, cr.surf.nl, FluxCD,
+  HelmRepository, or HelmRelease — even if they only paste a pipeline log or
+  kubectl output without an explicit question.
+---
+
+# SURF SDP Helm/Flux Deployment Conventions
+
+How deployments work on the SURF SDP (Kubernetes) platform, and how to
+diagnose them when they don't. Read this fully before proposing fixes to a
+pipeline log or Flux error someone pastes — most failures here are known
+patterns with known one-line fixes, and generic Helm/Flux advice wastes time.
+
+## Repo layout & local preview
+
+Config repos share this layout:
+
+```
+charts/<app>/Chart.yaml
+charts/<app>/values.yaml          # chart defaults
+manifests/base/values-base.yaml   # shared base overlay + Flux helmrelease/helmrepo/kustomization
+manifests/<env>/values.yaml       # per-env override (development/test/staging/playground/production)
+manifests/<env>/kustomization.yaml
+```
+
+Environments are **directories under `manifests/`** (not a `values-<env>.yaml`
+naming scheme); each env's `kustomization.yaml` patches base with its
+`values.yaml`. A base-wide change goes in `manifests/base/values-base.yaml`; an
+env-specific one in that env's file — don't cross them, and give `production`
+extra scrutiny.
+
+Preview what a change renders to **before committing** (never mutates a cluster):
+
+```bash
+helm template <release> charts/<app> \
+  -f charts/<app>/values.yaml \
+  -f manifests/base/values-base.yaml \
+  -f manifests/<env>/values.yaml
+# or, since Flux uses Kustomize overlays:
+kustomize build manifests/<env>
+```
+
+## Architecture: how a change reaches the cluster
+
+```
+git push / tag
+  → GitLab CI pipeline
+      build:   container image → Harbor (cr.surf.nl)
+      helm:package: chart version rewritten with yq, packaged,
+                    pushed as OCI artifact → Harbor
+  → FluxCD in the cluster
+      Kustomization (flux-system) syncs tenant namespace
+      HelmRepository (type: oci, secretRef to Harbor credentials)
+      HelmRelease pulls the chart, installs/upgrades
+  → pipeline verify job
+      waits for HelmRelease Ready condition
+      compares deployed chart version against expected version
+```
+
+Key properties of this setup:
+
+- **The pipeline never runs `helm upgrade` against the cluster directly.**
+  It pushes a chart and then *waits for Flux* to act. Any "deployment"
+  problem is therefore really one of: (a) chart not published correctly,
+  (b) Flux can't fetch it, or (c) Flux fetched it but the release fails.
+  Establish which of the three it is before doing anything else.
+- Chart versions carry semver build metadata tied to the commit:
+  `0.0.4-rc.197+5545fff1` or `0.0.1-build.20+branch.f085e792`.
+- Each tenant namespace gets its HelmRepository/HelmRelease from a
+  Kustomization in `flux-system` (label
+  `kustomize.toolkit.fluxcd.io/name=<tenant>-sync`). Hand-editing those
+  resources gets reverted by the next sync — fix the source repo instead.
+
+## Critical gotcha: `+` becomes `_` in OCI tags
+
+Semver build metadata uses `+`, but `+` is not a valid character in OCI
+tags. Harbor stores the chart under a tag with `_` instead:
+
+- Chart version: `0.0.1-build.20+testminio.f085e792`
+- Harbor tag:    `0.0.1-build.20_testminio.f085e792`
+
+Helm and Flux translate this automatically *most of the time*, but when you
+see a 404/"not found"/`unexpected status from HEAD request` for a chart you
+are sure exists, check both spellings before anything else. When manually
+verifying with `helm pull`, use the `_` form of the tag. The bundled
+`scripts/check-oci-tag.sh` does this check for you.
+
+A `401 Unauthorized` on chart pull is a different problem: the
+HelmRepository is missing its `secretRef` (Harbor credentials, e.g.
+`sdp-harbor-credentials`), or the referenced secret doesn't exist in the
+tenant namespace. A HelmRepository with a completely **empty `Status:`
+section and no events** in `kubectl describe` is the classic sign it never
+successfully connected at all.
+
+## Deploy verification: stuck vs. slow
+
+The verify job fails with something like:
+
+```
+ERROR: Deployed Helm Chart has version: 0.0.4-rc.189+2bc7cc59, expected: 0.0.4-rc.197+5545fff1
+error: timed out waiting for the condition on helmreleases/<name>
+```
+
+Do not immediately assume the deployment is broken. Two very different
+causes produce this identical output:
+
+1. **Still in progress.** Flux's upgrade action has its own timeout (often
+   5m) and background migrations/jobs can exceed the pipeline's wait.
+   Check: `kubectl get helmrelease <name> -n <ns>` — if the status shows
+   `Running 'upgrade' action`, it is slow, not stuck. Retry the verify job
+   after it settles.
+2. **Flux gave up and rolled back.** After exhausting `remediation`
+   retries, Flux rolls back to the last good release and *stops trying*.
+   The deployed version will stay at the old build forever. Check the
+   `history:` and `Released` condition in
+   `kubectl describe helmrelease <name> -n <ns>` for `UpgradeFailed`.
+   Recovery, in order of preference:
+   - fix the underlying failure and push a new commit (new build number
+     bypasses the poisoned release), or
+   - force a retry: `scripts/force-reconcile.sh <helmrelease> <namespace>`, or
+   - if it stays wedged: `flux suspend helmrelease <name> -n <ns>` followed
+     by `flux resume ...`.
+
+**Beware the wrong `flux` binary.** InfluxDB also ships a `flux` CLI (a
+query language tool). If `flux reconcile` errors with
+`unknown shorthand flag: 'n'` or the help output shows `fmt`/`test`
+subcommands, that's the InfluxDB one. Don't chase flag syntax — use the
+kubectl fallback, which always works:
+
+```bash
+kubectl annotate helmrelease <name> \
+  reconcile.fluxcd.io/requestedAt="$(date +%s)" \
+  -n <namespace> --overwrite
+```
+
+(`--overwrite` is required; the annotation usually already exists.)
+
+## Pipeline conventions
+
+### Chart packaging (`helm:package`)
+
+Runs in the `quay.io/helmpack/chart-testing` image (Alpine — install extras
+with `apk add --no-cache yq`). The chart version is rewritten from a
+pipeline-computed `CHART_VERSION` before packaging:
+
+```bash
+export TARGET_VERSION="$CHART_VERSION"
+yq eval -i '.version = strenv(TARGET_VERSION)' Chart.yaml
+helm package --dependency-update .
+```
+
+Never hardcode a version in `Chart.yaml`; it is always overwritten in CI.
+
+### Cross-pipeline triggers
+
+Upstream (e.g. an ETL image build) triggers the config repo's pipeline and
+hands over the exact image digest. Conventions:
+
+- Downstream has a `trigger:receive` job that validates incoming variables
+  and re-exports them via a **dotenv artifact** so later jobs can `needs:`
+  it and inherit the values.
+- Trigger routing uses two variables:
+  `$CI_PIPELINE_SOURCE == "trigger"` and a `$TRIGGER_ACTION` value naming
+  the component (e.g. `etl_wo`).
+- Component-selective deploys pass overrides through `HELM_UPGRADE_ARGS`,
+  always with `--reuse-values` so untouched components keep their config:
+
+```yaml
+etl-wo:deploy:
+  stage: deploy
+  variables:
+    HELM_UPGRADE_ARGS: >-
+      --set etlwoTransport.tag=$ETL_WO_IMAGE_DIGEST
+      --set etl.job.enabled=true
+      --set streamlit.enabled=false
+      --reuse-values
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_ACTION == "etl_wo"
+  needs:
+    - trigger:receive
+```
+
+Deploy by **image digest**, not floating tags. `tag: latest` with
+`pullPolicy: Always` is only acceptable as a temporary unblocking measure
+in test namespaces — flag it as debt if you see it.
+
+### Runners
+
+Jobs on protected branches are silently ignored by a runner unless the
+runner itself has the **Protected** flag set (Admin → Runners → edit →
+Protected ✓). If a job stays "pending" with a runner that is online and
+correctly tagged, check this flag before anything else — the symptom looks
+exactly like a tagging problem but isn't.
+
+## Troubleshooting quick reference
+
+| Symptom | Likely cause | First action |
+|---|---|---|
+| 401 pulling chart from cr.surf.nl | HelmRepository missing/wrong `secretRef` | `kubectl describe helmrepository <n> -n <ns>`; check secret exists |
+| 404 / HEAD error for chart that exists | `+` vs `_` tag mismatch | `scripts/check-oci-tag.sh` |
+| HelmRepository has empty `Status:` | Never connected (auth/URL) | Fix secretRef/URL in source repo, reconcile source |
+| Verify job: version mismatch + timeout | In progress **or** rolled back | `kubectl get hr <n> -n <ns>`; check for `UpgradeFailed` |
+| HelmRelease stuck after failures | Remediation retries exhausted | New build, or `scripts/force-reconcile.sh` |
+| `flux: unknown shorthand flag 'n'` | InfluxDB flux binary | Use kubectl annotate fallback |
+| Protected-branch job never picked up | Runner missing Protected flag | GitLab Admin → Runners → Protected ✓ |
+| Ingress `either defaultBackend or rules must be specified` | Component enabled with empty ingress values | Disable component or supply ingress host in values |
+
+For the full diagnostic command runbook (describe/get/watch sequences,
+suspend/resume, checking Kustomization sync, job log retrieval), read
+`references/diagnostics.md`.
+
+## Bundled scripts
+
+- `scripts/force-reconcile.sh <helmrelease> <namespace>` — force a Flux
+  retry using the flux CLI when available, kubectl annotate otherwise.
+- `scripts/check-oci-tag.sh <oci-url> <chart-version>` — checks whether a
+  chart version exists in the registry under the `+` and/or `_` tag form.
+- `scripts/hr-status.sh <helmrelease> <namespace>` — one-shot health
+  summary: HelmRelease conditions, history, HelmRepository status, recent
+  jobs in the namespace.

--- a/.claude/skills/surf-sdp-helm-flux/references/diagnostics.md
+++ b/.claude/skills/surf-sdp-helm-flux/references/diagnostics.md
@@ -1,0 +1,114 @@
+# Diagnostic runbook: Flux/Helm on SDP
+
+Work top-down: source → release → workload. Stop at the first broken layer;
+everything below it is noise.
+
+## 0. Orient
+
+```bash
+# What Flux resources exist in the tenant namespace?
+kubectl get helmrepositories,helmreleases -n <ns>
+
+# Which Kustomization owns them? (hand edits get reverted by this)
+kubectl get helmrelease <name> -n <ns> \
+  -o jsonpath='{.metadata.labels.kustomize\.toolkit\.fluxcd\.io/name}'
+```
+
+## 1. Source layer (HelmRepository)
+
+```bash
+kubectl describe helmrepository <name> -n <ns>
+```
+
+Healthy: `Status:` shows `Ready: True` with an artifact revision.
+Broken signs:
+
+- **Empty `Status:` and `Events: <none>`** → never connected. Check `URL:`
+  (must be `oci://cr.surf.nl/...`) and `Secret Ref:` name.
+- Verify the secret exists and is a docker-registry secret:
+
+```bash
+kubectl get secret sdp-harbor-credentials -n <ns> -o yaml | head
+```
+
+- Manual pull test (note the `_` tag form for versions with `+`):
+
+```bash
+helm pull oci://cr.surf.nl/<project>/<chart> --version '<version-with-_>'
+```
+
+## 2. Release layer (HelmRelease)
+
+```bash
+kubectl describe helmrelease <name> -n <ns>
+kubectl get helmrelease <name> -n <ns> -o yaml | grep -A 30 'status:'
+```
+
+Read these fields:
+
+- `conditions[type=Released]` — `UpgradeFailed` means Helm ran and the
+  release itself failed (template/values error, admission rejection).
+  The message contains the real error, e.g.
+  `Ingress "x" is invalid: spec: either defaultBackend or rules must be
+  specified` → a subchart/component is enabled but its ingress values are
+  empty.
+- `Running 'upgrade' action with timeout of 5m0s` — still in flight; wait.
+- `history:` — compare `chartVersion` of the last deployed entry with what
+  the pipeline expects. Old version + `failures: N` = rolled back.
+- `spec.install.remediation.retries: -1` means retry forever on *install*;
+  upgrade remediation is configured separately and usually is not infinite.
+
+Force a retry:
+
+```bash
+flux reconcile helmrelease <name> --namespace <ns>       # real flux CLI
+# or, always available:
+kubectl annotate helmrelease <name> \
+  reconcile.fluxcd.io/requestedAt="$(date +%s)" -n <ns> --overwrite
+```
+
+Unstick a wedged release:
+
+```bash
+flux suspend helmrelease <name> -n <ns>
+flux resume  helmrelease <name> -n <ns>
+```
+
+## 3. Workload layer
+
+```bash
+# Watch what the release actually creates
+kubectl get jobs,pods -n <ns> -w
+
+# Failed hook/migration job logs (job names are timestamped)
+kubectl logs job/<release>-<timestamp> -n <ns>
+
+# Events, most recent last
+kubectl get events -n <ns> --sort-by=.lastTimestamp | tail -20
+```
+
+Common finding: an image pull error on a job pod because the values point
+at a tag/digest that was never pushed — cross-check against the Harbor UI
+or `crane ls` / `helm pull`.
+
+## 4. Kustomization sync (when your fix "doesn't apply")
+
+If you changed HelmRepository/HelmRelease manifests in the config repo but
+the cluster doesn't reflect it:
+
+```bash
+kubectl get kustomization -n flux-system | grep <tenant>
+kubectl describe kustomization <tenant>-sync -n flux-system
+flux reconcile kustomization <tenant>-sync -n flux-system
+```
+
+Conversely: if you edited the live resource with kubectl and it reverted,
+that's this sync doing its job. Fix the repo.
+
+## 5. Post-renderer annotations
+
+SDP HelmReleases carry kustomize `postRenderers` that patch a
+`sdp.surf.nl/team: <team>` annotation onto Deployments, StatefulSets,
+ReplicaSets and DaemonSets. If a resource type is rejected during upgrade
+with a patch error, check whether the postRenderer patch targets match the
+API versions actually rendered by the chart.

--- a/.claude/skills/surf-sdp-helm-flux/scripts/check-oci-tag.sh
+++ b/.claude/skills/surf-sdp-helm-flux/scripts/check-oci-tag.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Check whether a Helm chart version exists in an OCI registry, testing both
+# the semver form (+build metadata) and the OCI tag form (+ replaced by _).
+#
+# Usage: check-oci-tag.sh <oci-url> <chart-version>
+# Example:
+#   check-oci-tag.sh oci://cr.surf.nl/ceda-instroom-config/instroom-config/instroom \
+#                    '0.0.1-build.20+testminio.f085e792'
+#
+# Requires: helm (logged in to the registry if it is private:
+#   helm registry login cr.surf.nl)
+set -uo pipefail
+
+URL="${1:?usage: check-oci-tag.sh <oci-url> <chart-version>}"
+VER="${2:?usage: check-oci-tag.sh <oci-url> <chart-version>}"
+
+UNDERSCORE_VER="${VER//+/_}"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+try_pull() {
+  local v="$1"
+  if helm pull "${URL}" --version "${v}" -d "${TMPDIR}" >/dev/null 2>&1; then
+    echo "FOUND:    ${URL}:${v}"
+    return 0
+  else
+    echo "missing:  ${URL}:${v}"
+    return 1
+  fi
+}
+
+echo "Checking chart tags for version '${VER}'"
+FOUND=1
+try_pull "${VER}" && FOUND=0
+if [ "${VER}" != "${UNDERSCORE_VER}" ]; then
+  try_pull "${UNDERSCORE_VER}" && FOUND=0
+fi
+
+if [ "${FOUND}" -ne 0 ]; then
+  echo
+  echo "Neither form found. Check:"
+  echo "  - are you logged in?  helm registry login cr.surf.nl"
+  echo "  - does the repo path match Harbor exactly (project/repo/chart)?"
+  echo "  - was the helm:package / push job in the pipeline successful?"
+  exit 1
+fi

--- a/.claude/skills/surf-sdp-helm-flux/scripts/force-reconcile.sh
+++ b/.claude/skills/surf-sdp-helm-flux/scripts/force-reconcile.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Force FluxCD to retry a HelmRelease.
+# Usage: force-reconcile.sh <helmrelease> <namespace>
+#
+# Prefers the real flux CLI; falls back to kubectl annotate, which also
+# sidesteps the classic trap of having the InfluxDB 'flux' binary in PATH.
+set -euo pipefail
+
+HR="${1:?usage: force-reconcile.sh <helmrelease> <namespace>}"
+NS="${2:?usage: force-reconcile.sh <helmrelease> <namespace>}"
+
+is_fluxcd_cli() {
+  # The InfluxDB flux CLI has 'fmt' and 'test' subcommands and no 'reconcile'.
+  command -v flux >/dev/null 2>&1 && flux --help 2>&1 | grep -q reconcile
+}
+
+if is_fluxcd_cli; then
+  echo ">> flux reconcile helmrelease ${HR} --namespace ${NS}"
+  flux reconcile helmrelease "${HR}" --namespace "${NS}"
+else
+  echo ">> fluxcd CLI not found (or InfluxDB flux detected); using kubectl annotate fallback"
+  kubectl annotate helmrelease "${HR}" \
+    "reconcile.fluxcd.io/requestedAt=$(date +%s)" \
+    -n "${NS}" --overwrite
+fi
+
+echo ">> watching status (Ctrl-C to stop)"
+kubectl get helmrelease "${HR}" -n "${NS}" -w

--- a/.claude/skills/surf-sdp-helm-flux/scripts/hr-status.sh
+++ b/.claude/skills/surf-sdp-helm-flux/scripts/hr-status.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# One-shot health summary for a Flux HelmRelease and its source.
+# Usage: hr-status.sh <helmrelease> <namespace>
+set -euo pipefail
+
+HR="${1:?usage: hr-status.sh <helmrelease> <namespace>}"
+NS="${2:?usage: hr-status.sh <helmrelease> <namespace>}"
+
+hdr() { printf '\n=== %s ===\n' "$1"; }
+
+hdr "HelmRelease ${HR} (${NS}) — conditions"
+kubectl get helmrelease "${HR}" -n "${NS}" \
+  -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}' \
+  | column -t -s $'\t' || true
+
+hdr "Deployed vs desired"
+kubectl get helmrelease "${HR}" -n "${NS}" \
+  -o jsonpath='desired: {.spec.chart.spec.version}{"\n"}last deployed: {.status.history[0].chartVersion}{"\n"}failures: {.status.failures}{"\n"}' || true
+
+hdr "Source (HelmRepository)"
+SRC="$(kubectl get helmrelease "${HR}" -n "${NS}" \
+  -o jsonpath='{.spec.chart.spec.sourceRef.name}')"
+if [ -n "${SRC}" ]; then
+  kubectl get helmrepository "${SRC}" -n "${NS}" -o wide || true
+  READY="$(kubectl get helmrepository "${SRC}" -n "${NS}" \
+    -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true)"
+  if [ -z "${READY}" ]; then
+    echo "WARNING: HelmRepository has no Ready condition / empty status."
+    echo "         Classic sign of auth or URL problems — check secretRef."
+  fi
+else
+  echo "(no HelmRepository sourceRef found — GitRepository-based release?)"
+fi
+
+hdr "Recent jobs in namespace"
+kubectl get jobs -n "${NS}" \
+  --sort-by=.metadata.creationTimestamp 2>/dev/null | tail -6 || true
+
+hdr "Recent events"
+kubectl get events -n "${NS}" --sort-by=.lastTimestamp 2>/dev/null | tail -10 || true


### PR DESCRIPTION
# Pull Request Description

## Type of Change
- [x] New feature

## Description of Changes
Voegt vier Claude-skills toe voor het **SURF Developer Platform (SDP)** en de GitLab config-repos:

- **gitlab-ci** — GitLab CI voor de `*-config` repos: SDP shared components, de branch→cluster `workflow.rules`, helm package/publish/promote en de kubernetes diff/dry-run/verify-stages.
- **sdp-onboard** — de weg van code naar een draaiende k8s-deploy op SDP: toegang (VPN/SSH), repo aanmaken via Terraform in `gitlab-config`, een tenant aanvragen, scaffolding kopiëren van een template-repo, en per-env manifests/URLs instellen.
- **surf-sdp-helm-flux** — Helm/Flux deploy-conventies én troubleshooting (Harbor OCI `cr.surf.nl`, de `+`→`_` tag-gotcha, stuck vs. slow HelmRelease, de InfluxDB-`flux`-binary-val), inclusief `scripts/` en `references/`.
- **sdp-secrets-management** — SOPS + AGE secrets: `.sops.yaml` creation rules, key management voor teams, GitLab CI-integratie, de tool-keuze-beslisboom en een error-catalogus, inclusief `scripts/` en `references/`.

## ⚠️ Author review requested
`surf-sdp-helm-flux` en `sdp-secrets-management` bestonden al als **persoonlijke** skills (waarschijnlijk door een teamlid geschreven) en worden hier naar de gedeelde repo gepromoveerd. Graag review door de oorspronkelijke auteur. Ik heb er twee kleine, additieve secties in gemerged:
- `surf-sdp-helm-flux`: een "Repo layout & local preview"-sectie (`charts/` + `manifests/<env>/` + een `helm template`/`kustomize build`-preview).
- `sdp-secrets-management`: een recept om een bestaande secret-waarde uit een draaiend cluster op te halen (`kubectl get secret … | base64 -d`).

Als de auteur die aanvullingen liever anders ziet, pas ik ze aan of haal ik ze eruit.

## Testing Instructions
- Frontmatter geldig in elke `SKILL.md`.
- Gebundelde `scripts/*.sh` en `references/*.md` zijn meegekomen.
- Interne `[[skill]]`-verwijzingen resolven (o.a. gitlab-ci/sdp-onboard → surf-sdp-helm-flux, sdp-secrets-management).

## Dependencies
Geen nieuwe. De skills verwijzen naar bestaande tooling (`glab`, `sops`, `age`, `flux`, `kubectl`, `helm`).

## Additional Information
De workflow-skills (ship, pr-reply, branch-pr, gate, actions-ci, pypi-project) staan in een aparte PR.

## Checklist
- [x] My code follows the project's coding standards
- [x] I have updated the documentation accordingly (skills zijn zelf de documentatie)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
