### PR TITLE
feat: add voorspellen skills (dataprep, classificatie, continu, ranking)

### DIFF
--- a/.claude/skills/voorspellen-classificatie/SKILL.md
+++ b/.claude/skills/voorspellen-classificatie/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: voorspellen-classificatie
+description: Bouw voorspelmodellen voor categorische uitkomsten (ja/nee of meerdere klassen) waar per individu een correcte voorspelling telt — bijv. "voorspel of een student uitvalt", "classificeer aanvragen als goedgekeurd/afgekeurd", "predict churn yes/no". Gebruik deze skill bij elke classificatietaak. LET OP — als het doel is een lijst te sorteren op risico en de top-N te selecteren (beperkte capaciteit, uitnodigingslijst, prioritering), gebruik dan de skill voorspellen-ranking in plaats van deze.
+---
+
+# Voorspellen: classificatie
+
+Doel: per rij een klasse voorspellen (uitval ja/nee, categorie A/B/C). Evaluatie op de kwaliteit van individuele voorspellingen.
+
+## Workflow
+
+When the user invokes `/voorspellen-classificatie [optioneel: bestandspad of doelvariabele]`:
+
+## Stap 0 — Check: is dit wel classificatie?
+
+Twee checks voordat je begint:
+1. **Ranking?** Vraag bij een binaire doelvariabele altijd eerst: gaat het om **harde ja/nee-beslissingen per individu**, of om **sorteren op risico en de top-N selecteren** (bijv. wie nodig je uit bij beperkte capaciteit)? In het tweede geval: gebruik de skill `/voorspellen-ranking`. Klassieke classificatie optimaliseert een beslisgrens bij 0,5 en negeert de volgorde binnen groepen; voor prioriteringslijsten is dat de verkeerde optimalisatie.
+2. **Tijdreeks?** Gaat het om het voorspellen van toekomstige gebeurtenissen over de tijd waarbij rijen tijdstippen zijn (bijv. "wordt volgende maand een piek")? Dan is dit forecasting, geen rij-gebaseerde classificatie — meld dat en gebruik een forecasting-aanpak. Bij data over meerdere jaren (paneldata): splits op tijd (train op eerdere jaren, test op het laatste jaar) in plaats van random.
+
+## Stap 1 — Intake (altijd eerst vragen, niet zelf aannemen)
+
+1. **Interpreteerbaar of black box?**
+   - Interpreteerbaar = uitlegbaar waarom (Logistische regressie, Lasso-logistiek, kleine beslisboom).
+   - Black box mag = vaak nauwkeuriger (Random Forest, Gradient Boosting, XGBoost, SVM). Geen deep learning.
+2. **Instellingen automatisch fijnslijpen of standaardinstellingen?** (vraag het in deze gewone taal, niet met termen als hyperparameters of cross-validatie)
+   - Standaard = snel, prima eerste versie.
+   - Fijnslijpen = het model probeert veel combinaties van instellingen uit en kiest de beste. Duurt langer. Technisch: zie `references/hyperparameters.md`.
+3. **Meerdere algoritmes benchmarken of één aanbeveling?**
+   - Benchmark = train alle passende algoritmes, één vergelijkingstabel (aanpak van cedanl/uitnodigingsregel-benchmark: RF, Lasso/LogReg, SVM, Gradient Boosting, XGBoost).
+   - Aanbeveling = beoordeel zelf de case en beveel één algoritme aan met korte motivering. Weeg mee: aantal rijen (logistische regressie sterk bij weinig data; boosting bij veel data), klassenbalans, veel categorische features (bomen), verwachte niet-lineariteit, en de interpretatie-eis uit vraag 1. Geen vaste default hardcoden.
+
+## Stap 2 — Data
+
+Is de data nog niet voorbereid, volg dan eerst de skill `/voorspellen-dataprep` (overzicht, leakage-check, missings, encoding, split). Kern, ook als die skill niet beschikbaar is:
+- Splits 80/20 stratified op de doelkolom (random_state=42) vóór preprocessing; alles in een sklearn Pipeline (geen leakage).
+- Missings imputeren (mediaan/modus), one-hot met handle_unknown="ignore", StandardScaler alleen voor logistische regressie en SVM.
+- Check klassenbalans. Bij scheve verdeling (< ~20% minderheidsklasse): rapporteer dit, gebruik class_weight="balanced" waar mogelijk en leun niet op accuracy.
+
+## Stap 3 — Algoritmes
+
+| Algoritme | Interpreteerbaar | Scaling |
+|---|---|---|
+| Logistische regressie | ja | ja |
+| Kleine beslisboom | ja | nee |
+| Random Forest | nee | nee |
+| Gradient Boosting | nee | nee |
+| XGBoost | nee | nee |
+| SVM (rbf, probability=True) | nee | ja |
+
+Geen neurale netwerken / deep learning.
+
+Bij tunen: gebruik de grids uit `references/hyperparameters.md` (scoring: "f1" of "roc_auc" bij onbalans). De zoekmethode kies je zelf (staat in dat bestand); val de gebruiker er niet mee lastig.
+
+## Stap 4 — Evaluatie en rapportage
+
+Rapporteer op de testset: accuracy, precision, recall, F1 (per klasse bij multiclass), confusion matrix, en ROC-AUC bij binaire uitkomst. Geef een baseline (meerderheidsklasse) ter context.
+
+Bij benchmark: één tabel, sorteer op F1 (of AUC bij onbalans), benoem de winnaar.
+
+Bij interpreteerbare modellen: coëfficiënten/odds-ratio's tonen. Bij ensembles: feature importances, met kanttekening dat dit geen causaliteit is.
+
+Lever op: (1) samenvatting in gewone taal, (2) herdraaibare code, (3) joblib-model op verzoek.
+
+## Important
+
+- Doel is sorteren op risico en top-N selecteren? Gebruik `/voorspellen-ranking`, niet deze skill.
+- Data nog niet voorbereid? Eerst `/voorspellen-dataprep`.
+- Intake (Stap 1) altijd eerst vragen — niet zelf aannemen; geen vast default-algoritme hardcoden.
+- Geen neurale netwerken / deep learning.
+- Splits altijd vóór preprocessing, alles in een sklearn Pipeline (geen leakage).
+- De gebruiker is niet technisch: leg keuzes uit in gewone taal, zonder jargon.

--- a/.claude/skills/voorspellen-classificatie/SKILL.md
+++ b/.claude/skills/voorspellen-classificatie/SKILL.md
@@ -22,14 +22,14 @@ Two checks before you start:
 Ask these in plain Dutch. Skip a question only if the answer is already in the conversation.
 
 1. **Interpretable or black box?**
-   - Interpretable = you can explain why (logistic regression, Lasso-logistic, small decision tree).
-   - Black box allowed = often more accurate (Random Forest, Gradient Boosting, XGBoost, SVM). No deep learning.
+   - Interpretable = you can explain why (e.g. logistic regression, Lasso-logistic, small decision tree, Random Forest) often appropriate for education.
+   - Black box allowed = often more accurate (e.g.g Gradient Boosting, XGBoost, SVM).
 2. **Automatically fine-tune settings or use default settings?** (ask this in plain language, not with terms like hyperparameters or cross-validation)
    - Default = fast, fine first version.
-   - Fine-tune = the model tries many combinations of settings and picks the best. Takes longer. Technical detail: see `references/hyperparameters.md`.
+   - Fine-tune = the model tries many combinations of settings and picks the best. Takes a lot longer. Technical detail: see `references/hyperparameters.md`.
 3. **Benchmark multiple algorithms or one recommendation?**
-   - Benchmark = train all suitable algorithms, one comparison table (the cedanl/uitnodigingsregel-benchmark approach: RF, Lasso/LogReg, SVM, Gradient Boosting, XGBoost).
-   - Recommendation = assess the case yourself and recommend one algorithm with a short rationale. Weigh: number of rows (logistic regression strong with little data; boosting with lots of data), class balance, many categorical features (trees), expected non-linearity, and the interpretability requirement from question 1. Do not hardcode a fixed default.
+   - Benchmark = train all suitable algorithms, one comparison table (e.g. cedanl/uitnodigingsregel-benchmark approach: RF, Lasso/LogReg, SVM, Gradient Boosting, XGBoost).
+   - Recommendation = llm assess the case and recommend one algorithm with a short rationale. Weigh: number of rows (logistic regression strong with little data; boosting with lots of data), class balance, many categorical features (trees), expected non-linearity, and the interpretability requirement from question 1. Do not hardcode a fixed default.
 
 ## Step 2 — Data
 
@@ -44,12 +44,11 @@ If the data is not yet prepared, first follow the skill `/voorspellen-dataprep` 
 |---|---|---|
 | Logistic regression | yes | yes |
 | Small decision tree | yes | no |
-| Random Forest | no | no |
+| Random Forest | yes | no |
 | Gradient Boosting | no | no |
 | XGBoost | no | no |
 | SVM (rbf, probability=True) | no | yes |
 
-No neural networks / deep learning.
 
 When tuning: use the grids from `references/hyperparameters.md` (scoring: "f1" or "roc_auc" for imbalance). Choose the search method yourself (it is described in that file); do not bother the user with it.
 
@@ -68,6 +67,5 @@ Deliver: (1) a summary in plain Dutch, (2) reproducible code, (3) a joblib model
 - Goal is to sort by risk and select the top-N? Use `/voorspellen-ranking`, not this skill.
 - Data not yet prepared? First `/voorspellen-dataprep`.
 - Intake (Step 1) always ask first — do not assume; do not hardcode a fixed default algorithm.
-- No neural networks / deep learning.
 - Always split before preprocessing, everything in an sklearn Pipeline (no leakage).
 - The user is non-technical: all output and questions to the user are in Dutch; explain choices in plain language, no jargon.

--- a/.claude/skills/voorspellen-classificatie/SKILL.md
+++ b/.claude/skills/voorspellen-classificatie/SKILL.md
@@ -3,69 +3,71 @@ name: voorspellen-classificatie
 description: Bouw voorspelmodellen voor categorische uitkomsten (ja/nee of meerdere klassen) waar per individu een correcte voorspelling telt — bijv. "voorspel of een student uitvalt", "classificeer aanvragen als goedgekeurd/afgekeurd", "predict churn yes/no". Gebruik deze skill bij elke classificatietaak. LET OP — als het doel is een lijst te sorteren op risico en de top-N te selecteren (beperkte capaciteit, uitnodigingslijst, prioritering), gebruik dan de skill voorspellen-ranking in plaats van deze.
 ---
 
-# Voorspellen: classificatie
+# Prediction: classification
 
-Doel: per rij een klasse voorspellen (uitval ja/nee, categorie A/B/C). Evaluatie op de kwaliteit van individuele voorspellingen.
+Goal: predict a class per row (dropout yes/no, category A/B/C). Evaluated on the quality of individual predictions. The user is non-technical: address them in Dutch and keep explanations in plain language.
 
 ## Workflow
 
-When the user invokes `/voorspellen-classificatie [optioneel: bestandspad of doelvariabele]`:
+When the user invokes `/voorspellen-classificatie [optional: file path or target variable]`:
 
-## Stap 0 — Check: is dit wel classificatie?
+## Step 0 — Check: is this actually classification?
 
-Twee checks voordat je begint:
-1. **Ranking?** Vraag bij een binaire doelvariabele altijd eerst: gaat het om **harde ja/nee-beslissingen per individu**, of om **sorteren op risico en de top-N selecteren** (bijv. wie nodig je uit bij beperkte capaciteit)? In het tweede geval: gebruik de skill `/voorspellen-ranking`. Klassieke classificatie optimaliseert een beslisgrens bij 0,5 en negeert de volgorde binnen groepen; voor prioriteringslijsten is dat de verkeerde optimalisatie.
-2. **Tijdreeks?** Gaat het om het voorspellen van toekomstige gebeurtenissen over de tijd waarbij rijen tijdstippen zijn (bijv. "wordt volgende maand een piek")? Dan is dit forecasting, geen rij-gebaseerde classificatie — meld dat en gebruik een forecasting-aanpak. Bij data over meerdere jaren (paneldata): splits op tijd (train op eerdere jaren, test op het laatste jaar) in plaats van random.
+Two checks before you start:
+1. **Ranking?** For a binary target, always ask first: is this about **hard yes/no decisions per individual**, or about **sorting by risk and selecting the top-N** (e.g. who to invite under limited capacity)? In the second case: use the skill `/voorspellen-ranking`. Classic classification optimises a decision boundary at 0.5 and ignores the ordering within groups; for prioritisation lists that is the wrong optimisation.
+2. **Time series?** Is this about predicting future events over time where rows are timestamps (e.g. "will there be a peak next month")? Then this is forecasting, not row-based classification — say so and use a forecasting approach. For data across multiple years (panel data): split on time (train on earlier years, test on the most recent year) instead of random.
 
-## Stap 1 — Intake (altijd eerst vragen, niet zelf aannemen)
+## Step 1 — Intake (always ask first, do not assume)
 
-1. **Interpreteerbaar of black box?**
-   - Interpreteerbaar = uitlegbaar waarom (Logistische regressie, Lasso-logistiek, kleine beslisboom).
-   - Black box mag = vaak nauwkeuriger (Random Forest, Gradient Boosting, XGBoost, SVM). Geen deep learning.
-2. **Instellingen automatisch fijnslijpen of standaardinstellingen?** (vraag het in deze gewone taal, niet met termen als hyperparameters of cross-validatie)
-   - Standaard = snel, prima eerste versie.
-   - Fijnslijpen = het model probeert veel combinaties van instellingen uit en kiest de beste. Duurt langer. Technisch: zie `references/hyperparameters.md`.
-3. **Meerdere algoritmes benchmarken of één aanbeveling?**
-   - Benchmark = train alle passende algoritmes, één vergelijkingstabel (aanpak van cedanl/uitnodigingsregel-benchmark: RF, Lasso/LogReg, SVM, Gradient Boosting, XGBoost).
-   - Aanbeveling = beoordeel zelf de case en beveel één algoritme aan met korte motivering. Weeg mee: aantal rijen (logistische regressie sterk bij weinig data; boosting bij veel data), klassenbalans, veel categorische features (bomen), verwachte niet-lineariteit, en de interpretatie-eis uit vraag 1. Geen vaste default hardcoden.
+Ask these in plain Dutch. Skip a question only if the answer is already in the conversation.
 
-## Stap 2 — Data
+1. **Interpretable or black box?**
+   - Interpretable = you can explain why (logistic regression, Lasso-logistic, small decision tree).
+   - Black box allowed = often more accurate (Random Forest, Gradient Boosting, XGBoost, SVM). No deep learning.
+2. **Automatically fine-tune settings or use default settings?** (ask this in plain language, not with terms like hyperparameters or cross-validation)
+   - Default = fast, fine first version.
+   - Fine-tune = the model tries many combinations of settings and picks the best. Takes longer. Technical detail: see `references/hyperparameters.md`.
+3. **Benchmark multiple algorithms or one recommendation?**
+   - Benchmark = train all suitable algorithms, one comparison table (the cedanl/uitnodigingsregel-benchmark approach: RF, Lasso/LogReg, SVM, Gradient Boosting, XGBoost).
+   - Recommendation = assess the case yourself and recommend one algorithm with a short rationale. Weigh: number of rows (logistic regression strong with little data; boosting with lots of data), class balance, many categorical features (trees), expected non-linearity, and the interpretability requirement from question 1. Do not hardcode a fixed default.
 
-Is de data nog niet voorbereid, volg dan eerst de skill `/voorspellen-dataprep` (overzicht, leakage-check, missings, encoding, split). Kern, ook als die skill niet beschikbaar is:
-- Splits 80/20 stratified op de doelkolom (random_state=42) vóór preprocessing; alles in een sklearn Pipeline (geen leakage).
-- Missings imputeren (mediaan/modus), one-hot met handle_unknown="ignore", StandardScaler alleen voor logistische regressie en SVM.
-- Check klassenbalans. Bij scheve verdeling (< ~20% minderheidsklasse): rapporteer dit, gebruik class_weight="balanced" waar mogelijk en leun niet op accuracy.
+## Step 2 — Data
 
-## Stap 3 — Algoritmes
+If the data is not yet prepared, first follow the skill `/voorspellen-dataprep` (overview, leakage check, missings, encoding, split). Core, also if that skill is unavailable:
+- Split 80/20 stratified on the target column (random_state=42) before preprocessing; everything in an sklearn Pipeline (no leakage).
+- Impute missings (median/mode), one-hot with handle_unknown="ignore", StandardScaler only for logistic regression and SVM.
+- Check class balance. For a skewed distribution (< ~20% minority class): report it, use class_weight="balanced" where possible and do not rely on accuracy.
 
-| Algoritme | Interpreteerbaar | Scaling |
+## Step 3 — Algorithms
+
+| Algorithm | Interpretable | Scaling |
 |---|---|---|
-| Logistische regressie | ja | ja |
-| Kleine beslisboom | ja | nee |
-| Random Forest | nee | nee |
-| Gradient Boosting | nee | nee |
-| XGBoost | nee | nee |
-| SVM (rbf, probability=True) | nee | ja |
+| Logistic regression | yes | yes |
+| Small decision tree | yes | no |
+| Random Forest | no | no |
+| Gradient Boosting | no | no |
+| XGBoost | no | no |
+| SVM (rbf, probability=True) | no | yes |
 
-Geen neurale netwerken / deep learning.
+No neural networks / deep learning.
 
-Bij tunen: gebruik de grids uit `references/hyperparameters.md` (scoring: "f1" of "roc_auc" bij onbalans). De zoekmethode kies je zelf (staat in dat bestand); val de gebruiker er niet mee lastig.
+When tuning: use the grids from `references/hyperparameters.md` (scoring: "f1" or "roc_auc" for imbalance). Choose the search method yourself (it is described in that file); do not bother the user with it.
 
-## Stap 4 — Evaluatie en rapportage
+## Step 4 — Evaluation and reporting
 
-Rapporteer op de testset: accuracy, precision, recall, F1 (per klasse bij multiclass), confusion matrix, en ROC-AUC bij binaire uitkomst. Geef een baseline (meerderheidsklasse) ter context.
+Report on the test set: accuracy, precision, recall, F1 (per class for multiclass), confusion matrix, and ROC-AUC for a binary outcome. Give a baseline (majority class) for context.
 
-Bij benchmark: één tabel, sorteer op F1 (of AUC bij onbalans), benoem de winnaar.
+For a benchmark: one table, sort by F1 (or AUC for imbalance), name the winner.
 
-Bij interpreteerbare modellen: coëfficiënten/odds-ratio's tonen. Bij ensembles: feature importances, met kanttekening dat dit geen causaliteit is.
+For interpretable models: show coefficients/odds ratios. For ensembles: feature importances, with the caveat that this is not causality.
 
-Lever op: (1) samenvatting in gewone taal, (2) herdraaibare code, (3) joblib-model op verzoek.
+Deliver: (1) a summary in plain Dutch, (2) reproducible code, (3) a joblib model on request.
 
 ## Important
 
-- Doel is sorteren op risico en top-N selecteren? Gebruik `/voorspellen-ranking`, niet deze skill.
-- Data nog niet voorbereid? Eerst `/voorspellen-dataprep`.
-- Intake (Stap 1) altijd eerst vragen — niet zelf aannemen; geen vast default-algoritme hardcoden.
-- Geen neurale netwerken / deep learning.
-- Splits altijd vóór preprocessing, alles in een sklearn Pipeline (geen leakage).
-- De gebruiker is niet technisch: leg keuzes uit in gewone taal, zonder jargon.
+- Goal is to sort by risk and select the top-N? Use `/voorspellen-ranking`, not this skill.
+- Data not yet prepared? First `/voorspellen-dataprep`.
+- Intake (Step 1) always ask first — do not assume; do not hardcode a fixed default algorithm.
+- No neural networks / deep learning.
+- Always split before preprocessing, everything in an sklearn Pipeline (no leakage).
+- The user is non-technical: all output and questions to the user are in Dutch; explain choices in plain language, no jargon.

--- a/.claude/skills/voorspellen-classificatie/references/hyperparameters.md
+++ b/.claude/skills/voorspellen-classificatie/references/hyperparameters.md
@@ -1,6 +1,6 @@
 # Hyperparameter-grids (classificatie)
 
-Werkbare zoekruimtes voor algemene classificatie. Zoekmethode (interne keuze, nooit aan de gebruiker vragen): GridSearchCV als de grid ≤ ~60 combinaties telt, anders RandomizedSearchCV(n_iter=50). Altijd cv=5 (StratifiedKFold), n_jobs=-1, random_state=42; scoring="f1" of "roc_auc" bij onbalans, anders "accuracy" of "f1_macro" (multiclass).
+Werkbare zoekruimtes voor algemene classificatie. Zoekmethode (default, niet aan de gebruiker vragen, maar gebruiker kan wijzigen): GridSearchCV als de grid ≤ ~60 combinaties telt, anders RandomizedSearchCV(n_iter=50). Altijd cv=5 (StratifiedKFold), n_jobs=-1, random_state=42; scoring="f1" of "roc_auc" bij onbalans, anders "accuracy" of "f1_macro" (multiclass).
 
 ```python
 PARAM_GRIDS = {

--- a/.claude/skills/voorspellen-classificatie/references/hyperparameters.md
+++ b/.claude/skills/voorspellen-classificatie/references/hyperparameters.md
@@ -1,0 +1,54 @@
+# Hyperparameter-grids (classificatie)
+
+Werkbare zoekruimtes voor algemene classificatie. Zoekmethode (interne keuze, nooit aan de gebruiker vragen): GridSearchCV als de grid ≤ ~60 combinaties telt, anders RandomizedSearchCV(n_iter=50). Altijd cv=5 (StratifiedKFold), n_jobs=-1, random_state=42; scoring="f1" of "roc_auc" bij onbalans, anders "accuracy" of "f1_macro" (multiclass).
+
+```python
+PARAM_GRIDS = {
+    "LogisticRegression": {  # geschaalde input; solver="saga", max_iter=10_000
+        "C": [0.01, 0.1, 1, 10, 100],
+        "penalty": ["elasticnet"],
+        "l1_ratio": [0.0, 0.5, 1.0],
+        "class_weight": [None, "balanced"],
+    },
+    "DecisionTree": {
+        "max_depth": [2, 3, 4, 6],
+        "min_samples_leaf": [3, 5, 10],
+        "min_samples_split": [2, 5, 10],
+        "class_weight": [None, "balanced"],
+    },
+    "RandomForest": {
+        "bootstrap": [True, False],
+        "max_depth": [3, 5, 10, None],
+        "max_features": ["sqrt", "log2", None],
+        "min_samples_leaf": [1, 3, 5],
+        "min_samples_split": [2, 5, 10],
+        "n_estimators": [100, 200, 300],
+        "class_weight": [None, "balanced"],
+    },
+    "GradientBoosting": {
+        "n_estimators": [100, 200, 400],
+        "learning_rate": [0.02, 0.05, 0.1, 0.2],
+        "max_depth": [2, 3, 5],
+        "subsample": [0.8, 1.0],
+    },
+    "XGBoost": {  # eval_metric="logloss", verbosity=0; optioneel, sla over als niet installeerbaar
+        "n_estimators": [100, 200, 400],
+        "learning_rate": [0.02, 0.05, 0.1, 0.2],
+        "max_depth": [2, 3, 5, 7],
+        "subsample": [0.8, 1.0],
+        "colsample_bytree": [0.8, 1.0],
+        # bij onbalans: "scale_pos_weight": [1, n_neg/n_pos]
+    },
+    "SVM": {  # geschaalde input; SVC(probability=True); overslaan bij > ~10.000 rijen (te traag)
+        "C": [0.1, 1, 10, 100, 1000],
+        "gamma": ["scale", 0.001, 0.01, 0.1, 1],
+        "kernel": ["rbf"],
+        "class_weight": [None, "balanced"],
+    },
+}
+```
+
+Richtlijnen:
+- Grids zijn vertrekpunten. Optimum op de rand: grid die kant uitbreiden en opnieuw zoeken.
+- Kleine datasets (< ~1000 rijen): ondiepe bomen (max_depth ≤ 4). Grote datasets (> ~50k): cv=3, n_iter=30.
+- Wil je resultaten vergelijkbaar met cedanl/uitnodigingsregel-benchmark, gebruik dan exact de grids uit models.py van die repo (o.a. RF max_depth [2,3,4], max_features [3,4,5]).

--- a/.claude/skills/voorspellen-continu/SKILL.md
+++ b/.claude/skills/voorspellen-continu/SKILL.md
@@ -3,73 +3,73 @@ name: voorspellen-continu
 description: Bouw voorspelmodellen voor continue (numerieke) doelvariabelen zoals cijfers, studiepunten, aantallen of bedragen. Gebruik deze skill altijd wanneer de gebruiker een getal wil voorspellen op basis van data (regressie), ook als het woord "regressie" niet valt — bijv. "voorspel het eindcijfer", "schat het aantal EC", "predict grade/score/amount". NIET gebruiken voor ja/nee-uitkomsten (classificatie) of het rangschikken op risico (ranking).
 ---
 
-# Voorspellen: continue doelvariabele (regressie)
+# Prediction: continuous target (regression)
 
-Doel: een model dat een getal voorspelt per rij (student, klant, ...). Evaluatie op afwijking tussen voorspelling en werkelijkheid.
+Goal: a model that predicts a number per row (student, customer, ...). Evaluated on the deviation between prediction and reality. The user is non-technical: address them in Dutch and keep explanations in plain language.
 
 ## Workflow
 
-When the user invokes `/voorspellen-continu [optioneel: bestandspad of doelvariabele]`:
+When the user invokes `/voorspellen-continu [optional: file path or target variable]`:
 
-## Stap 0 — Check: is dit geen tijdreeks-forecasting?
+## Step 0 — Check: is this not time-series forecasting?
 
-Als het doel is **toekomstige waarden over de tijd** te voorspellen (instroom volgend jaar, omzet per maand, bezetting per week) en de rijen zijn tijdstippen in plaats van individuen, dan is dit tijdreeks-forecasting, geen rij-gebaseerde regressie. Meld dat aan de gebruiker en gebruik deze skill dan niet: een random 80/20-split lekt dan toekomst in de training en de metrics worden misleidend. Gebruik een forecasting-aanpak (lag-features + temporele split, of een forecasting-skill als die beschikbaar is). Twijfelgeval (paneldata: individuen gevolgd over jaren): rij-gebaseerd modelleren mag, maar splits dan op tijd (train op eerdere jaren, test op het laatste jaar).
+If the goal is to predict **future values over time** (enrolment next year, revenue per month, occupancy per week) and the rows are timestamps instead of individuals, then this is time-series forecasting, not row-based regression. Tell the user and do not use this skill: a random 80/20 split then leaks the future into training and the metrics become misleading. Use a forecasting approach (lag features + temporal split, or a forecasting skill if available). Edge case (panel data: individuals followed across years): row-based modelling is allowed, but split on time then (train on earlier years, test on the most recent year).
 
-## Stap 1 — Intake (altijd eerst vragen, niet zelf aannemen)
+## Step 1 — Intake (always ask first, do not assume)
 
-Stel deze drie vragen aan de gebruiker voordat je gaat modelleren. Kort en in gewone taal. Sla vragen alleen over als het antwoord al in het gesprek staat.
+Ask the user these three questions before modelling. Short and in plain Dutch. Skip a question only if the answer is already in the conversation.
 
-1. **Interpreteerbaar of black box?**
-   - Interpreteerbaar = je kunt uitleggen waarom het model iets voorspelt (Lasso, lineaire regressie, kleine beslisboom). Nodig als resultaten verantwoord moeten worden aan bijv. examencommissie of studenten.
-   - Black box mag = vaak nauwkeuriger (Random Forest, Gradient Boosting, XGBoost, SVR). Geen deep learning.
-2. **Instellingen automatisch fijnslijpen of standaardinstellingen?** (vraag het in deze gewone taal, niet met termen als hyperparameters of cross-validatie)
-   - Standaard = snel, meestal prima als eerste versie.
-   - Fijnslijpen = het model probeert veel combinaties van instellingen uit en kiest de beste. Duurt langer, vaak iets betere scores. Technisch: zie `references/hyperparameters.md`.
-3. **Meerdere algoritmes benchmarken of één aanbeveling?**
-   - Benchmark = train alle passende algoritmes, vergelijk in één tabel.
-   - Aanbeveling = beoordeel zelf de case en beveel één algoritme aan met korte motivering. Weeg mee: aantal rijen (SVR traag en linear vaak beter bij < ~500 rijen; boosting wint meestal bij veel data), aantal features vs rijen, veel categorische features (bomen), verwachte niet-lineariteit, en de interpretatie-eis uit vraag 1. Geen vaste default hardcoden.
+1. **Interpretable or black box?**
+   - Interpretable = you can explain why the model predicts something (Lasso, linear regression, small decision tree). Needed when results must be justified to e.g. an exam board or students.
+   - Black box allowed = often more accurate (Random Forest, Gradient Boosting, XGBoost, SVR). No deep learning.
+2. **Automatically fine-tune settings or use default settings?** (ask this in plain language, not with terms like hyperparameters or cross-validation)
+   - Default = fast, usually fine as a first version.
+   - Fine-tune = the model tries many combinations of settings and picks the best. Takes longer, often slightly better scores. Technical detail: see `references/hyperparameters.md`.
+3. **Benchmark multiple algorithms or one recommendation?**
+   - Benchmark = train all suitable algorithms, compare in one table.
+   - Recommendation = assess the case yourself and recommend one algorithm with a short rationale. Weigh: number of rows (SVR slow and linear often better at < ~500 rows; boosting usually wins with lots of data), features vs rows, many categorical features (trees), expected non-linearity, and the interpretability requirement from question 1. Do not hardcode a fixed default.
 
-## Stap 2 — Data
+## Step 2 — Data
 
-Is de data nog niet voorbereid, volg dan eerst de skill `/voorspellen-dataprep` (overzicht, leakage-check, missings, encoding, split). Kern, ook als die skill niet beschikbaar is:
-- Doelkolom moet numeriek en continu zijn. Binair (0/1)? Verwijs naar `/voorspellen-classificatie` of `/voorspellen-ranking`.
-- Splits 80/20 (random_state=42) vóór alle preprocessing; alles in een sklearn Pipeline (geen leakage).
-- Missings imputeren (mediaan/modus), one-hot met handle_unknown="ignore", StandardScaler alleen voor Lasso/lineair/SVR.
+If the data is not yet prepared, first follow the skill `/voorspellen-dataprep` (overview, leakage check, missings, encoding, split). Core, also if that skill is unavailable:
+- The target column must be numeric and continuous. Binary (0/1)? Refer to `/voorspellen-classificatie` or `/voorspellen-ranking`.
+- Split 80/20 (random_state=42) before all preprocessing; everything in an sklearn Pipeline (no leakage).
+- Impute missings (median/mode), one-hot with handle_unknown="ignore", StandardScaler only for Lasso/linear/SVR.
 
-## Stap 3 — Algoritmes
+## Step 3 — Algorithms
 
-Kies uit (afhankelijk van intake-antwoord 1):
+Choose from (depending on intake answer 1):
 
-| Algoritme | Interpreteerbaar | Scaling |
+| Algorithm | Interpretable | Scaling |
 |---|---|---|
-| Lasso | ja | ja |
-| Lineaire regressie (Ridge/ElasticNet) | ja | ja |
-| Kleine beslisboom | ja | nee |
-| Random Forest Regressor | nee | nee |
-| Gradient Boosting Regressor | nee | nee |
-| XGBoost Regressor | nee | nee |
-| SVR | nee | ja |
+| Lasso | yes | yes |
+| Linear regression (Ridge/ElasticNet) | yes | yes |
+| Small decision tree | yes | no |
+| Random Forest Regressor | no | no |
+| Gradient Boosting Regressor | no | no |
+| XGBoost Regressor | no | no |
+| SVR | no | yes |
 
-Geen neurale netwerken / deep learning gebruiken.
+Do not use neural networks / deep learning.
 
-Bij tunen: gebruik de grids uit `references/hyperparameters.md`. De zoekmethode kies je zelf (staat in dat bestand); val de gebruiker er niet mee lastig.
+When tuning: use the grids from `references/hyperparameters.md`. Choose the search method yourself (it is described in that file); do not bother the user with it.
 
-## Stap 4 — Evaluatie en rapportage
+## Step 4 — Evaluation and reporting
 
-Rapporteer op de testset: RMSE, MAE, R². Geef ook een baseline (voorspel altijd het gemiddelde) zodat de scores context hebben.
+Report on the test set: RMSE, MAE, R². Also give a baseline (always predict the mean) so the scores have context.
 
-Bij benchmark: één vergelijkingstabel, sorteer op RMSE, benoem de winnaar en of het verschil praktisch relevant is.
+For a benchmark: one comparison table, sort by RMSE, name the winner and whether the difference is practically relevant.
 
-Bij interpreteerbare modellen: toon coëfficiënten (Lasso: welke features vallen weg). Bij boom-ensembles: feature importances, met de kanttekening dat dit richtinggevend is, geen causaliteit.
+For interpretable models: show coefficients (Lasso: which features drop out). For tree ensembles: feature importances, with the caveat that this is indicative, not causality.
 
-Lever op: (1) korte samenvatting in gewone taal, (2) code die de gebruiker kan herdraaien, (3) opgeslagen model (joblib) als daarom gevraagd wordt.
+Deliver: (1) a short summary in plain Dutch, (2) code the user can re-run, (3) a saved model (joblib) if requested.
 
 ## Important
 
-- Alleen voor continue (numerieke) doelvariabelen. Ja/nee → `/voorspellen-classificatie`; sorteren op risico → `/voorspellen-ranking`.
-- Tijdreeks-forecasting (rijen = tijdstippen)? Niet deze skill; meld het en splits op tijd.
-- Data nog niet voorbereid? Eerst `/voorspellen-dataprep`.
-- Intake (Stap 1) altijd eerst vragen — niet zelf aannemen; geen vast default-algoritme hardcoden.
-- Geen neurale netwerken / deep learning.
-- Splits altijd vóór preprocessing, alles in een sklearn Pipeline (geen leakage).
-- De gebruiker is niet technisch: leg keuzes uit in gewone taal, zonder jargon.
+- Only for continuous (numeric) targets. Yes/no → `/voorspellen-classificatie`; sorting by risk → `/voorspellen-ranking`.
+- Time-series forecasting (rows = timestamps)? Not this skill; say so and split on time.
+- Data not yet prepared? First `/voorspellen-dataprep`.
+- Intake (Step 1) always ask first — do not assume; do not hardcode a fixed default algorithm.
+- No neural networks / deep learning.
+- Always split before preprocessing, everything in an sklearn Pipeline (no leakage).
+- The user is non-technical: all output and questions to the user are in Dutch; explain choices in plain language, no jargon.

--- a/.claude/skills/voorspellen-continu/SKILL.md
+++ b/.claude/skills/voorspellen-continu/SKILL.md
@@ -20,14 +20,14 @@ If the goal is to predict **future values over time** (enrolment next year, reve
 Ask the user these three questions before modelling. Short and in plain Dutch. Skip a question only if the answer is already in the conversation.
 
 1. **Interpretable or black box?**
-   - Interpretable = you can explain why the model predicts something (Lasso, linear regression, small decision tree). Needed when results must be justified to e.g. an exam board or students.
-   - Black box allowed = often more accurate (Random Forest, Gradient Boosting, XGBoost, SVR). No deep learning.
+   - Interpretable = you can explain why the model predicts something (e.g. Lasso, linear regression, small decision tree, Random Forest). Needed when results must be justified to e.g. an exam board or students.
+   - Black box allowed = often more accurate (e.g. Gradient Boosting, XGBoost, SVR). 
 2. **Automatically fine-tune settings or use default settings?** (ask this in plain language, not with terms like hyperparameters or cross-validation)
    - Default = fast, usually fine as a first version.
-   - Fine-tune = the model tries many combinations of settings and picks the best. Takes longer, often slightly better scores. Technical detail: see `references/hyperparameters.md`.
+   - Fine-tune = the model tries many combinations of settings and picks the best. Takes a lot longer, often slightly better scores. Technical detail: see `references/hyperparameters.md`.
 3. **Benchmark multiple algorithms or one recommendation?**
    - Benchmark = train all suitable algorithms, compare in one table.
-   - Recommendation = assess the case yourself and recommend one algorithm with a short rationale. Weigh: number of rows (SVR slow and linear often better at < ~500 rows; boosting usually wins with lots of data), features vs rows, many categorical features (trees), expected non-linearity, and the interpretability requirement from question 1. Do not hardcode a fixed default.
+   - Recommendation = llm assess the case and recommend one algorithm with a short rationale. Weigh: number of rows (SVR slow and linear often better at < ~500 rows; boosting usually wins with lots of data), features vs rows, many categorical features (trees), expected non-linearity, and the interpretability requirement from question 1. Do not hardcode a fixed default.
 
 ## Step 2 — Data
 
@@ -45,12 +45,11 @@ Choose from (depending on intake answer 1):
 | Lasso | yes | yes |
 | Linear regression (Ridge/ElasticNet) | yes | yes |
 | Small decision tree | yes | no |
-| Random Forest Regressor | no | no |
+| Random Forest Regressor | yes | no |
 | Gradient Boosting Regressor | no | no |
 | XGBoost Regressor | no | no |
 | SVR | no | yes |
 
-Do not use neural networks / deep learning.
 
 When tuning: use the grids from `references/hyperparameters.md`. Choose the search method yourself (it is described in that file); do not bother the user with it.
 
@@ -70,6 +69,5 @@ Deliver: (1) a short summary in plain Dutch, (2) code the user can re-run, (3) a
 - Time-series forecasting (rows = timestamps)? Not this skill; say so and split on time.
 - Data not yet prepared? First `/voorspellen-dataprep`.
 - Intake (Step 1) always ask first — do not assume; do not hardcode a fixed default algorithm.
-- No neural networks / deep learning.
 - Always split before preprocessing, everything in an sklearn Pipeline (no leakage).
 - The user is non-technical: all output and questions to the user are in Dutch; explain choices in plain language, no jargon.

--- a/.claude/skills/voorspellen-continu/SKILL.md
+++ b/.claude/skills/voorspellen-continu/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: voorspellen-continu
+description: Bouw voorspelmodellen voor continue (numerieke) doelvariabelen zoals cijfers, studiepunten, aantallen of bedragen. Gebruik deze skill altijd wanneer de gebruiker een getal wil voorspellen op basis van data (regressie), ook als het woord "regressie" niet valt — bijv. "voorspel het eindcijfer", "schat het aantal EC", "predict grade/score/amount". NIET gebruiken voor ja/nee-uitkomsten (classificatie) of het rangschikken op risico (ranking).
+---
+
+# Voorspellen: continue doelvariabele (regressie)
+
+Doel: een model dat een getal voorspelt per rij (student, klant, ...). Evaluatie op afwijking tussen voorspelling en werkelijkheid.
+
+## Workflow
+
+When the user invokes `/voorspellen-continu [optioneel: bestandspad of doelvariabele]`:
+
+## Stap 0 — Check: is dit geen tijdreeks-forecasting?
+
+Als het doel is **toekomstige waarden over de tijd** te voorspellen (instroom volgend jaar, omzet per maand, bezetting per week) en de rijen zijn tijdstippen in plaats van individuen, dan is dit tijdreeks-forecasting, geen rij-gebaseerde regressie. Meld dat aan de gebruiker en gebruik deze skill dan niet: een random 80/20-split lekt dan toekomst in de training en de metrics worden misleidend. Gebruik een forecasting-aanpak (lag-features + temporele split, of een forecasting-skill als die beschikbaar is). Twijfelgeval (paneldata: individuen gevolgd over jaren): rij-gebaseerd modelleren mag, maar splits dan op tijd (train op eerdere jaren, test op het laatste jaar).
+
+## Stap 1 — Intake (altijd eerst vragen, niet zelf aannemen)
+
+Stel deze drie vragen aan de gebruiker voordat je gaat modelleren. Kort en in gewone taal. Sla vragen alleen over als het antwoord al in het gesprek staat.
+
+1. **Interpreteerbaar of black box?**
+   - Interpreteerbaar = je kunt uitleggen waarom het model iets voorspelt (Lasso, lineaire regressie, kleine beslisboom). Nodig als resultaten verantwoord moeten worden aan bijv. examencommissie of studenten.
+   - Black box mag = vaak nauwkeuriger (Random Forest, Gradient Boosting, XGBoost, SVR). Geen deep learning.
+2. **Instellingen automatisch fijnslijpen of standaardinstellingen?** (vraag het in deze gewone taal, niet met termen als hyperparameters of cross-validatie)
+   - Standaard = snel, meestal prima als eerste versie.
+   - Fijnslijpen = het model probeert veel combinaties van instellingen uit en kiest de beste. Duurt langer, vaak iets betere scores. Technisch: zie `references/hyperparameters.md`.
+3. **Meerdere algoritmes benchmarken of één aanbeveling?**
+   - Benchmark = train alle passende algoritmes, vergelijk in één tabel.
+   - Aanbeveling = beoordeel zelf de case en beveel één algoritme aan met korte motivering. Weeg mee: aantal rijen (SVR traag en linear vaak beter bij < ~500 rijen; boosting wint meestal bij veel data), aantal features vs rijen, veel categorische features (bomen), verwachte niet-lineariteit, en de interpretatie-eis uit vraag 1. Geen vaste default hardcoden.
+
+## Stap 2 — Data
+
+Is de data nog niet voorbereid, volg dan eerst de skill `/voorspellen-dataprep` (overzicht, leakage-check, missings, encoding, split). Kern, ook als die skill niet beschikbaar is:
+- Doelkolom moet numeriek en continu zijn. Binair (0/1)? Verwijs naar `/voorspellen-classificatie` of `/voorspellen-ranking`.
+- Splits 80/20 (random_state=42) vóór alle preprocessing; alles in een sklearn Pipeline (geen leakage).
+- Missings imputeren (mediaan/modus), one-hot met handle_unknown="ignore", StandardScaler alleen voor Lasso/lineair/SVR.
+
+## Stap 3 — Algoritmes
+
+Kies uit (afhankelijk van intake-antwoord 1):
+
+| Algoritme | Interpreteerbaar | Scaling |
+|---|---|---|
+| Lasso | ja | ja |
+| Lineaire regressie (Ridge/ElasticNet) | ja | ja |
+| Kleine beslisboom | ja | nee |
+| Random Forest Regressor | nee | nee |
+| Gradient Boosting Regressor | nee | nee |
+| XGBoost Regressor | nee | nee |
+| SVR | nee | ja |
+
+Geen neurale netwerken / deep learning gebruiken.
+
+Bij tunen: gebruik de grids uit `references/hyperparameters.md`. De zoekmethode kies je zelf (staat in dat bestand); val de gebruiker er niet mee lastig.
+
+## Stap 4 — Evaluatie en rapportage
+
+Rapporteer op de testset: RMSE, MAE, R². Geef ook een baseline (voorspel altijd het gemiddelde) zodat de scores context hebben.
+
+Bij benchmark: één vergelijkingstabel, sorteer op RMSE, benoem de winnaar en of het verschil praktisch relevant is.
+
+Bij interpreteerbare modellen: toon coëfficiënten (Lasso: welke features vallen weg). Bij boom-ensembles: feature importances, met de kanttekening dat dit richtinggevend is, geen causaliteit.
+
+Lever op: (1) korte samenvatting in gewone taal, (2) code die de gebruiker kan herdraaien, (3) opgeslagen model (joblib) als daarom gevraagd wordt.
+
+## Important
+
+- Alleen voor continue (numerieke) doelvariabelen. Ja/nee → `/voorspellen-classificatie`; sorteren op risico → `/voorspellen-ranking`.
+- Tijdreeks-forecasting (rijen = tijdstippen)? Niet deze skill; meld het en splits op tijd.
+- Data nog niet voorbereid? Eerst `/voorspellen-dataprep`.
+- Intake (Stap 1) altijd eerst vragen — niet zelf aannemen; geen vast default-algoritme hardcoden.
+- Geen neurale netwerken / deep learning.
+- Splits altijd vóór preprocessing, alles in een sklearn Pipeline (geen leakage).
+- De gebruiker is niet technisch: leg keuzes uit in gewone taal, zonder jargon.

--- a/.claude/skills/voorspellen-continu/references/hyperparameters.md
+++ b/.claude/skills/voorspellen-continu/references/hyperparameters.md
@@ -1,6 +1,6 @@
 # Hyperparameter-grids (regressie)
 
-Werkbare zoekruimtes voor algemene regressie. Zoekmethode (interne keuze, nooit aan de gebruiker vragen): GridSearchCV als de grid ≤ ~60 combinaties telt, anders RandomizedSearchCV(n_iter=50). Altijd cv=5, n_jobs=-1, random_state=42, scoring="neg_root_mean_squared_error".
+Werkbare zoekruimtes voor algemene regressie. Zoekmethode (default, niet aan de gebruiker vragen, gebruiker mag wel wijzigen): GridSearchCV als de grid ≤ ~60 combinaties telt, anders RandomizedSearchCV(n_iter=50). Altijd cv=5, n_jobs=-1, random_state=42, scoring="neg_root_mean_squared_error".
 
 ```python
 PARAM_GRIDS = {

--- a/.claude/skills/voorspellen-continu/references/hyperparameters.md
+++ b/.claude/skills/voorspellen-continu/references/hyperparameters.md
@@ -1,0 +1,59 @@
+# Hyperparameter-grids (regressie)
+
+Werkbare zoekruimtes voor algemene regressie. Zoekmethode (interne keuze, nooit aan de gebruiker vragen): GridSearchCV als de grid ≤ ~60 combinaties telt, anders RandomizedSearchCV(n_iter=50). Altijd cv=5, n_jobs=-1, random_state=42, scoring="neg_root_mean_squared_error".
+
+```python
+PARAM_GRIDS = {
+    "Lasso": {  # geschaalde input; let op: passende alpha hangt af van de schaal van y
+        "alpha": [0.0001, 0.001, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0],
+        "max_iter": [10_000],
+    },
+    "Ridge": {  # geschaalde input
+        "alpha": [0.01, 0.1, 1, 10, 100],
+    },
+    "ElasticNet": {  # geschaalde input
+        "alpha": [0.001, 0.01, 0.1, 0.5, 1.0],
+        "l1_ratio": [0.1, 0.3, 0.5, 0.7, 0.9],
+        "max_iter": [10_000],
+    },
+    "DecisionTree": {
+        "max_depth": [2, 3, 4, 6],
+        "min_samples_leaf": [3, 5, 10],
+        "min_samples_split": [2, 5, 10],
+    },
+    "RandomForest": {
+        "bootstrap": [True, False],
+        "max_depth": [3, 5, 10, None],
+        "max_features": ["sqrt", "log2", None],
+        "min_samples_leaf": [1, 3, 5],
+        "min_samples_split": [2, 5, 10],
+        "n_estimators": [100, 200, 300],
+    },
+    "GradientBoosting": {
+        "n_estimators": [100, 200, 400],
+        "learning_rate": [0.02, 0.05, 0.1, 0.2],
+        "max_depth": [2, 3, 5],
+        "subsample": [0.8, 1.0],
+        "min_samples_leaf": [1, 5, 10],
+    },
+    "XGBoost": {  # optioneel; sla over als xgboost niet installeerbaar is
+        "n_estimators": [100, 200, 400],
+        "learning_rate": [0.02, 0.05, 0.1, 0.2],
+        "max_depth": [2, 3, 5, 7],
+        "subsample": [0.8, 1.0],
+        "colsample_bytree": [0.8, 1.0],
+        "min_child_weight": [1, 5],
+    },
+    "SVR": {  # geschaalde input; overslaan bij > ~10.000 rijen (te traag), tenzij de gebruiker erom vraagt
+        "C": [0.1, 1, 10, 100, 1000],
+        "gamma": ["scale", 0.001, 0.01, 0.1, 1],
+        "kernel": ["rbf"],
+        "epsilon": [0.01, 0.1, 0.5],
+    },
+}
+```
+
+Richtlijnen:
+- Deze grids zijn vertrekpunten, geen wet. Ligt het optimum op de rand van de grid, breid die kant uit en zoek opnieuw.
+- Kleine datasets (< ~1000 rijen): houd bomen ondiep (max_depth ≤ 4) en regularisatie hoog; grote datasets (> ~50k): cv=3 en n_iter=30 om rekentijd te beperken.
+- Ondiepe bomen (max_depth 2–4) passen bij weinig features en weinig rijen (zoals de uitnodigingsregel-context); bij bredere datasets is dat te restrictief — vandaar de ruimere waardes hierboven.

--- a/.claude/skills/voorspellen-dataprep/SKILL.md
+++ b/.claude/skills/voorspellen-dataprep/SKILL.md
@@ -67,4 +67,3 @@ StandardScaler in the pipeline, applied only for linear models and SVM (the foll
 - Always split before fitting the imputer/encoder/scaler — otherwise test information leaks into training.
 - The leakage check (Step 4) is the most important step and cannot be fully automated: always ask the user for confirmation before removing columns.
 - The user is non-technical: all output and questions to the user are in Dutch; explain each choice in one plain-language sentence, no jargon without explanation.
-- cedanl use only: row-based prediction, not time-series forecasting.

--- a/.claude/skills/voorspellen-dataprep/SKILL.md
+++ b/.claude/skills/voorspellen-dataprep/SKILL.md
@@ -3,68 +3,68 @@ name: voorspellen-dataprep
 description: Bereid een dataset voor op voorspelmodellen (regressie, classificatie of risicoranking). Gebruik deze skill altijd als eerste stap wanneer de gebruiker data wil klaarmaken, opschonen of controleren voor een voorspelling — bijv. "maak mijn CSV klaar voor het model", "check of deze data bruikbaar is", "voorspel X op basis van dit bestand" — en ook wanneer een van de skills voorspellen-continu, voorspellen-classificatie of voorspellen-ranking wordt gebruikt en de data nog niet is voorbereid.
 ---
 
-# Datapreparatie voor voorspelmodellen
+# Data preparation for prediction models
 
-Doel: van ruwe data naar een schone train/test-opzet waarmee de skills `/voorspellen-continu`, `/voorspellen-classificatie` en `/voorspellen-ranking` direct verder kunnen. Alles gebeurt in een sklearn Pipeline/ColumnTransformer zodat er geen leakage is en de stappen herdraaibaar zijn. De gebruiker is niet technisch: leg elke keuze in één zin gewone taal uit en vraag alleen wat echt nodig is.
+Goal: go from raw data to a clean train/test setup that the skills `/voorspellen-continu`, `/voorspellen-classificatie` and `/voorspellen-ranking` can continue with directly. Everything happens inside an sklearn Pipeline/ColumnTransformer so there is no leakage and the steps are reproducible. The user is non-technical: address them in Dutch, explain each choice in one plain-language sentence, and ask only what is genuinely needed.
 
 ## Workflow
 
-When the user invokes `/voorspellen-dataprep [optioneel: bestandspad]`:
+When the user invokes `/voorspellen-dataprep [optional: file path]`:
 
-## Stap 1 — Inlezen en overzicht
+## Step 1 — Load and overview
 
-- Lees het bestand in en toon: aantal rijen, aantal kolommen, per kolom het type en het percentage missende waarden.
-- Bevestig met de gebruiker welke kolom de doelvariabele is (wat voorspeld moet worden) als dat niet al duidelijk is.
+- Read the file and show: number of rows, number of columns, per column the type and the percentage of missing values.
+- Confirm with the user which column is the target variable (what must be predicted) if that is not already clear.
 
-## Stap 2 — Routekeuze
+## Step 2 — Route choice
 
-Bepaal het doeltype en benoem de vervolgskill:
-- Continu getal → `/voorspellen-continu`
-- Categorie, harde ja/nee-beslissing per individu → `/voorspellen-classificatie`
-- Binair label, maar het doel is sorteren op risico en top-N selecteren → `/voorspellen-ranking`
-- Rijen zijn tijdstippen en het doel is de toekomst over de tijd voorspellen → tijdreeks-forecasting; meld dat deze skills daar niet voor zijn.
+Determine the target type and name the follow-up skill:
+- Continuous number → `/voorspellen-continu`
+- Category, hard yes/no decision per individual → `/voorspellen-classificatie`
+- Binary label, but the goal is to sort by risk and select the top-N → `/voorspellen-ranking`
+- Rows are timestamps and the goal is to predict the future over time → time-series forecasting; state that these skills are not for that.
 
-## Stap 3 — Opschonen
+## Step 3 — Cleaning
 
-- Verwijder rijen waar de doelvariabele zelf ontbreekt (die zijn onbruikbaar voor trainen; meld hoeveel).
-- Verwijder exacte duplicaatrijen (meld hoeveel).
-- Verwijder ID-achtige kolommen (uniek per rij: studentnummer, e-mail) en constante kolommen. Benoem welke.
-- Fix datatypes (getallen die als tekst staan, datums parsen).
+- Remove rows where the target variable itself is missing (unusable for training; report how many).
+- Remove exact duplicate rows (report how many).
+- Remove ID-like columns (unique per row: student number, email) and constant columns. Name which ones.
+- Fix data types (numbers stored as text, parse dates).
 
-## Stap 4 — Leakage-check (belangrijkste stap)
+## Step 4 — Leakage check (most important step)
 
-Loop de kolommen langs op informatie die de uitkomst verraadt of pas ná het voorspelmoment ontstaat (bijv. "uitschrijfdatum" bij het voorspellen van uitval, eindcijfer bij het voorspellen van slagen). Leg de gebruiker in gewone taal voor welke kolommen verdacht zijn en vraag bevestiging om ze te verwijderen. Dit kan niet volledig automatisch: de gebruiker weet wat wanneer bekend is.
+Go through the columns for information that gives away the outcome or only comes into existence after the prediction moment (e.g. "de-registration date" when predicting dropout, final grade when predicting passing). Explain to the user in plain language which columns are suspect and ask for confirmation before removing them. This cannot be fully automated: the user knows what is known when.
 
-## Stap 5 — Missende waarden
+## Step 5 — Missing values
 
-- Kolommen met > 50% missend: voorstellen te verwijderen (met de gebruiker afstemmen).
-- Overige: SimpleImputer in de pipeline — mediaan voor numeriek, meest voorkomende waarde of aparte categorie "onbekend" voor categorisch. Meld wat je deed.
+- Columns with > 50% missing: propose removing them (confirm with the user).
+- Others: SimpleImputer in the pipeline — median for numeric, most frequent value or a separate "onbekend" (unknown) category for categorical. Report what you did.
 
-## Stap 6 — Categorische kolommen
+## Step 6 — Categorical columns
 
-- One-hot encoding met handle_unknown="ignore".
-- Hoge cardinaliteit (> ~20 categorieën): groepeer zeldzame categorieën (< ~1% van de rijen) samen tot "overig" vóór het encoden.
+- One-hot encoding with handle_unknown="ignore".
+- High cardinality (> ~20 categories): group rare categories (< ~1% of the rows) together into "overig" (other) before encoding.
 
-## Stap 7 — Train/test-split
+## Step 7 — Train/test split
 
-Altijd vóór het fitten van imputer/encoder/scaler:
-- Standaard: 80/20, random_state=42; stratified op de doelkolom bij classificatie en ranking.
-- Data over meerdere jaren/cohorten: splits op tijd (train op eerdere jaren, test op het laatste jaar) — dat lijkt op echt gebruik.
+Always before fitting the imputer/encoder/scaler:
+- Default: 80/20, random_state=42; stratified on the target column for classification and ranking.
+- Data across multiple years/cohorts: split on time (train on earlier years, test on the most recent year) — this resembles real use.
 
-## Stap 8 — Scaling
+## Step 8 — Scaling
 
-StandardScaler in de pipeline, alleen toegepast voor lineaire modellen en SVM (de vervolgskill bepaalt dit). Boommodellen hebben het niet nodig.
+StandardScaler in the pipeline, applied only for linear models and SVM (the follow-up skill decides this). Tree models do not need it.
 
-## Stap 9 — Oplevering
+## Step 9 — Delivery
 
-- Een ColumnTransformer/Pipeline die alle bovenstaande stappen bevat, plus X_train, X_test, y_train, y_test.
-- Kort rapport in gewone taal: wat is verwijderd, wat is geïmputeerd, hoe is gesplitst, klassenbalans (bij binaire doelen), en eventuele zorgen (weinig rijen, scheve verdeling, verdachte kolommen).
-- Ga daarna door met de passende voorspel-skill uit Stap 2.
+- A ColumnTransformer/Pipeline containing all of the above steps, plus X_train, X_test, y_train, y_test.
+- A short report in plain Dutch: what was removed, what was imputed, how it was split, class balance (for binary targets), and any concerns (few rows, skewed distribution, suspect columns).
+- Then continue with the appropriate prediction skill from Step 2.
 
 ## Important
 
-- Altijd eerste stap vóór `/voorspellen-continu`, `/voorspellen-classificatie` of `/voorspellen-ranking` als de data nog niet is voorbereid.
-- Splits altijd vóór het fitten van imputer/encoder/scaler — anders lekt testinformatie in de training.
-- De leakage-check (Stap 4) is de belangrijkste stap en kan niet volledig automatisch: vraag de gebruiker altijd om bevestiging voor je kolommen verwijdert.
-- De gebruiker is niet technisch: leg elke keuze in één zin gewone taal uit; geen jargon zonder uitleg.
-- Alleen cedanl-gebruik: rij-gebaseerde voorspelling, geen tijdreeks-forecasting.
+- Always the first step before `/voorspellen-continu`, `/voorspellen-classificatie` or `/voorspellen-ranking` when the data is not yet prepared.
+- Always split before fitting the imputer/encoder/scaler — otherwise test information leaks into training.
+- The leakage check (Step 4) is the most important step and cannot be fully automated: always ask the user for confirmation before removing columns.
+- The user is non-technical: all output and questions to the user are in Dutch; explain each choice in one plain-language sentence, no jargon without explanation.
+- cedanl use only: row-based prediction, not time-series forecasting.

--- a/.claude/skills/voorspellen-dataprep/SKILL.md
+++ b/.claude/skills/voorspellen-dataprep/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: voorspellen-dataprep
+description: Bereid een dataset voor op voorspelmodellen (regressie, classificatie of risicoranking). Gebruik deze skill altijd als eerste stap wanneer de gebruiker data wil klaarmaken, opschonen of controleren voor een voorspelling — bijv. "maak mijn CSV klaar voor het model", "check of deze data bruikbaar is", "voorspel X op basis van dit bestand" — en ook wanneer een van de skills voorspellen-continu, voorspellen-classificatie of voorspellen-ranking wordt gebruikt en de data nog niet is voorbereid.
+---
+
+# Datapreparatie voor voorspelmodellen
+
+Doel: van ruwe data naar een schone train/test-opzet waarmee de skills `/voorspellen-continu`, `/voorspellen-classificatie` en `/voorspellen-ranking` direct verder kunnen. Alles gebeurt in een sklearn Pipeline/ColumnTransformer zodat er geen leakage is en de stappen herdraaibaar zijn. De gebruiker is niet technisch: leg elke keuze in één zin gewone taal uit en vraag alleen wat echt nodig is.
+
+## Workflow
+
+When the user invokes `/voorspellen-dataprep [optioneel: bestandspad]`:
+
+## Stap 1 — Inlezen en overzicht
+
+- Lees het bestand in en toon: aantal rijen, aantal kolommen, per kolom het type en het percentage missende waarden.
+- Bevestig met de gebruiker welke kolom de doelvariabele is (wat voorspeld moet worden) als dat niet al duidelijk is.
+
+## Stap 2 — Routekeuze
+
+Bepaal het doeltype en benoem de vervolgskill:
+- Continu getal → `/voorspellen-continu`
+- Categorie, harde ja/nee-beslissing per individu → `/voorspellen-classificatie`
+- Binair label, maar het doel is sorteren op risico en top-N selecteren → `/voorspellen-ranking`
+- Rijen zijn tijdstippen en het doel is de toekomst over de tijd voorspellen → tijdreeks-forecasting; meld dat deze skills daar niet voor zijn.
+
+## Stap 3 — Opschonen
+
+- Verwijder rijen waar de doelvariabele zelf ontbreekt (die zijn onbruikbaar voor trainen; meld hoeveel).
+- Verwijder exacte duplicaatrijen (meld hoeveel).
+- Verwijder ID-achtige kolommen (uniek per rij: studentnummer, e-mail) en constante kolommen. Benoem welke.
+- Fix datatypes (getallen die als tekst staan, datums parsen).
+
+## Stap 4 — Leakage-check (belangrijkste stap)
+
+Loop de kolommen langs op informatie die de uitkomst verraadt of pas ná het voorspelmoment ontstaat (bijv. "uitschrijfdatum" bij het voorspellen van uitval, eindcijfer bij het voorspellen van slagen). Leg de gebruiker in gewone taal voor welke kolommen verdacht zijn en vraag bevestiging om ze te verwijderen. Dit kan niet volledig automatisch: de gebruiker weet wat wanneer bekend is.
+
+## Stap 5 — Missende waarden
+
+- Kolommen met > 50% missend: voorstellen te verwijderen (met de gebruiker afstemmen).
+- Overige: SimpleImputer in de pipeline — mediaan voor numeriek, meest voorkomende waarde of aparte categorie "onbekend" voor categorisch. Meld wat je deed.
+
+## Stap 6 — Categorische kolommen
+
+- One-hot encoding met handle_unknown="ignore".
+- Hoge cardinaliteit (> ~20 categorieën): groepeer zeldzame categorieën (< ~1% van de rijen) samen tot "overig" vóór het encoden.
+
+## Stap 7 — Train/test-split
+
+Altijd vóór het fitten van imputer/encoder/scaler:
+- Standaard: 80/20, random_state=42; stratified op de doelkolom bij classificatie en ranking.
+- Data over meerdere jaren/cohorten: splits op tijd (train op eerdere jaren, test op het laatste jaar) — dat lijkt op echt gebruik.
+
+## Stap 8 — Scaling
+
+StandardScaler in de pipeline, alleen toegepast voor lineaire modellen en SVM (de vervolgskill bepaalt dit). Boommodellen hebben het niet nodig.
+
+## Stap 9 — Oplevering
+
+- Een ColumnTransformer/Pipeline die alle bovenstaande stappen bevat, plus X_train, X_test, y_train, y_test.
+- Kort rapport in gewone taal: wat is verwijderd, wat is geïmputeerd, hoe is gesplitst, klassenbalans (bij binaire doelen), en eventuele zorgen (weinig rijen, scheve verdeling, verdachte kolommen).
+- Ga daarna door met de passende voorspel-skill uit Stap 2.
+
+## Important
+
+- Altijd eerste stap vóór `/voorspellen-continu`, `/voorspellen-classificatie` of `/voorspellen-ranking` als de data nog niet is voorbereid.
+- Splits altijd vóór het fitten van imputer/encoder/scaler — anders lekt testinformatie in de training.
+- De leakage-check (Stap 4) is de belangrijkste stap en kan niet volledig automatisch: vraag de gebruiker altijd om bevestiging voor je kolommen verwijdert.
+- De gebruiker is niet technisch: leg elke keuze in één zin gewone taal uit; geen jargon zonder uitleg.
+- Alleen cedanl-gebruik: rij-gebaseerde voorspelling, geen tijdreeks-forecasting.

--- a/.claude/skills/voorspellen-ranking/SKILL.md
+++ b/.claude/skills/voorspellen-ranking/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: voorspellen-ranking
+description: Bouw risicoscore-modellen (bipartite ranking) die individuen sorteren van hoog naar laag risico, voor situaties met beperkte capaciteit waarin je de top-N selecteert — bijv. een uitnodigingsregel voor studenten met uitvalrisico, prioriteringslijsten, triage, "wie moeten we als eerste benaderen". Gebruik deze skill altijd bij woorden als uitnodigingsregel, risicoscore, risicoprioritering, top-N, ranking op uitval/churn/risico, learning to rank met binaire labels — óók als de gebruiker het "classificatie" noemt maar het doel een gesorteerde lijst is. De ranking-benadering is methodologisch onderbouwd in Eegdeman et al. (2022) en wordt in de praktijk toegepast in de uitnodigingsregel van cedanl; daar blijkt dat sorteren op risicoscore bij beperkte capaciteit betere selecties oplevert dan classificatie met een vaste beslisgrens.
+---
+
+# Voorspellen: bipartite ranking (risicoscore / uitnodigingsregel)
+
+Doel: geen harde ja/nee-labels, maar een **score per individu** waarmee je sorteert van hoog naar laag risico. Het model is goed als de echte positieven (bijv. uitvallers) bovenaan staan — niet als elke individuele voorspelling "goed" of "fout" is. Evaluatie op rangorde-kwaliteit (AUC, precision@k), niet op accuracy. Klassieke classificatie optimaliseert een beslisgrens bij 0,5 en negeert de volgorde binnen de groepen; voor een lijst met beperkte capaciteit (top-N uitnodigen) wil je juist die volgorde goed hebben. Gebaseerd op cedanl/Uitnodigingsregel (Eegdeman et al., 2022). Verwante termen: learning to rank, AUC optimization.
+
+## Workflow
+
+When the user invokes `/voorspellen-ranking [optioneel: bestandspad of doelvariabele]`:
+
+## Stap 0 — Check: is dit geen tijdreeks-forecasting?
+
+Als de vraag is hoe een aantal of percentage zich **over de tijd** ontwikkelt (bijv. "hoeveel uitval verwachten we volgend jaar"), is dat forecasting, geen ranking van individuen — meld dat en gebruik deze skill niet. Deze skill is voor: individuen nu sorteren op risico.
+
+## Stap 1 — Intake (altijd eerst vragen, niet zelf aannemen)
+
+1. **Wat is de capaciteit (N of k)?** Hoeveel mensen kunnen er uitgenodigd/behandeld worden? Nodig voor precision@k. Onbekend: rapporteer bij meerdere k's (bijv. 5%, 10%, 20% van de populatie).
+2. **Interpreteerbaar of black box?**
+   - Interpreteerbaar = uitlegbaar waarom iemand hoog scoort (Lasso, logistische regressie). Vaak vereist bij besluiten over studenten.
+   - Black box mag = vaak betere rangorde (Random Forest, Gradient Boosting, XGBoost, SVM). Geen deep learning.
+3. **Instellingen automatisch fijnslijpen of standaardinstellingen?** (vraag het in deze gewone taal, niet met termen als hyperparameters, AUC of grids)
+   - Standaard = snel, prima eerste versie.
+   - Fijnslijpen = het model probeert veel combinaties van instellingen uit en kiest de beste. Duurt langer.
+   - Intern, niet aan de gebruiker voorleggen: tune op scoring="roc_auc" (rangorde, niet accuracy); gebruik standaard de lokale grids uit `references/hyperparameters.md`; alleen als de gebruiker zelf CEDA, de benchmark of vergelijkbaarheid tussen instellingen noemt, de CEDA-grids.
+4. **Meerdere modellen testen en vergelijken, of één aanbeveling volgen?** (in gewone taal vragen)
+   - Vergelijken = aanpak van cedanl/uitnodigingsregel-benchmark: Random Forest, Lasso, SVM, Gradient Boosting, XGBoost naast elkaar, één tabel.
+   - Aanbeveling = beoordeel zelf de case en beveel één algoritme aan met korte motivering. Weeg mee: aantal rijen en features, prevalentie van de positieve klasse, verwachte niet-lineariteit, en de interpretatie-eis uit vraag 2. Geen vaste default hardcoden. Benchmarkresultaten van cedanl mogen als context dienen, niet als automatisch antwoord.
+
+## Stap 2 — Data
+
+- Binaire doelkolom (bijv. `Dropout` 0/1). Continue doelvariabele → skill `/voorspellen-continu`.
+- Is de data nog niet voorbereid, volg dan eerst de skill `/voorspellen-dataprep` (overzicht, leakage-check, missings, encoding, split).
+- Splits 80/20 stratified (random_state=42) vóór preprocessing; alles in een Pipeline (geen leakage). Als er jaren beschikbaar zijn: liever trainen op eerdere jaren en testen op het laatste jaar (zoals config.yaml in de benchmark: training_years vs dropout_year) — dat lijkt op echt gebruik.
+- Missings imputeren (mediaan/modus), one-hot met handle_unknown="ignore", StandardScaler alleen voor Lasso, logistische regressie en SVM.
+- Klassenonbalans is hier normaal en geen probleem: ranking gebruikt de hele scoreverdeling; niet oversamplen tenzij expliciet gevraagd.
+
+## Stap 3 — Score maken
+
+Twee gangbare routes (cedanl/Uitnodigingsregel gebruikt beide):
+- **Classifier met `predict_proba`**: gebruik de kans op de positieve klasse als score (LogReg, RF-classifier, GB, XGBoost, SVC met probability=True).
+- **Regressor op het 0/1-label**: bijv. Lasso of RandomForestRegressor op de Dropout-kolom; de continue voorspelling is de score.
+
+Gebruik **nooit** `predict()` met de 0,5-drempel als eindresultaat. De output is altijd: score → sorteren aflopend → rang.
+
+Bij tunen: **scoring="roc_auc"** (bij regressor-route: custom AUC-scorer op de scores). Zoekmethode volgens `references/hyperparameters.md`; niet aan de gebruiker vragen.
+
+## Stap 4 — Evaluatie en rapportage
+
+Evalueer op de testset uitsluitend op rangorde-kwaliteit:
+- **AUC (ROC-AUC)**: kans dat een willekeurige positieve boven een willekeurige negatieve staat. 0,5 = random.
+- **Precision@k**: van de top-k op de lijst, welk aandeel is echt positief.
+- **Recall@k**: welk aandeel van alle positieven zit in de top-k.
+- **Precision/recall-curve over alle drempels** (zoals compute_dynamic_evaluation in cedanl/Uitnodigingsregel): cumulatief per rang, van hoogste score naar laagste.
+- Baseline: random ranking (precision@k = prevalentie).
+
+Rapporteer géén accuracy en géén confusion matrix bij drempel 0,5; leg kort uit waarom als de gebruiker erom vraagt.
+
+Bij benchmark: één tabel met AUC en precision@k per algoritme, sorteer op AUC, benoem de winnaar en of het verschil bij de relevante k iets uitmaakt.
+
+Lever op: (1) gesorteerde lijst met scores en rang (top-N gemarkeerd), (2) samenvatting in gewone taal, (3) herdraaibare code, (4) joblib-model op verzoek. Vermeld bij besluiten over personen dat de lijst een prioriteringshulp is, geen oordeel per individu.
+
+## Important
+
+- Voor top-N selectie bij beperkte capaciteit; harde ja/nee per individu → `/voorspellen-classificatie`, continue uitkomst → `/voorspellen-continu`.
+- Data nog niet voorbereid? Eerst `/voorspellen-dataprep`.
+- Gebruik **nooit** `predict()` met de 0,5-drempel als eindresultaat; output is altijd score → sorteren → rang.
+- Rapporteer géén accuracy of confusion matrix; evalueer op rangorde (AUC, precision@k).
+- Intake (Stap 1) altijd eerst vragen — niet zelf aannemen; geen vast default-algoritme hardcoden.
+- Geen neurale netwerken / deep learning.
+- Bij besluiten over personen: de lijst is een prioriteringshulp, geen oordeel per individu.

--- a/.claude/skills/voorspellen-ranking/SKILL.md
+++ b/.claude/skills/voorspellen-ranking/SKILL.md
@@ -19,15 +19,15 @@ If the question is how a count or percentage develops **over time** (e.g. "how m
 
 1. **What is the capacity (N or k)?** How many people can be invited/handled? Needed for precision@k. Unknown: report at multiple k's (e.g. 5%, 10%, 20% of the population).
 2. **Interpretable or black box?**
-   - Interpretable = explainable why someone scores high (Lasso, logistic regression). Often required for decisions about students.
-   - Black box allowed = often better ranking (Random Forest, Gradient Boosting, XGBoost, SVM). No deep learning.
+   - Interpretable = explainable why someone scores high (e.g. Lasso, logistic regression, Random Forest). Often required for decisions about students.
+   - Black box allowed = often better ranking (e.g. Gradient Boosting, XGBoost, SVM). 
 3. **Automatically fine-tune settings or use default settings?** (ask this in plain language, not with terms like hyperparameters, AUC or grids)
    - Default = fast, fine first version.
-   - Fine-tune = the model tries many combinations of settings and picks the best. Takes longer.
-   - Internal, do not put to the user: tune on scoring="roc_auc" (ranking, not accuracy); use the local grids from `references/hyperparameters.md` by default; only if the user themselves mentions CEDA, the benchmark or comparability between settings, the CEDA grids.
+   - Fine-tune = the model tries many combinations of settings and picks the best. Takes a lot longer.
+   - Internal, do not put to the user: tune on scoring="roc_auc" (ranking, not accuracy); use the local grids from `references/hyperparameters.md` by default; only if the user themselves mentions the CEDA benchmark or comparability between settings, the CEDA grids.
 4. **Test and compare multiple models, or follow one recommendation?** (ask in plain language)
    - Compare = the cedanl/uitnodigingsregel-benchmark approach: Random Forest, Lasso, SVM, Gradient Boosting, XGBoost side by side, one table.
-   - Recommendation = assess the case yourself and recommend one algorithm with a short rationale. Weigh: number of rows and features, prevalence of the positive class, expected non-linearity, and the interpretability requirement from question 2. Do not hardcode a fixed default. cedanl benchmark results may serve as context, not as an automatic answer.
+   - Recommendation = llm assess the case and recommend one algorithm with a short rationale. Weigh: number of rows and features, prevalence of the positive class, expected non-linearity, and the interpretability requirement from question 2. Do not hardcode a fixed default. cedanl benchmark results may serve as context, not as an automatic answer.
 
 ## Step 2 — Data
 
@@ -69,6 +69,5 @@ Deliver: (1) a sorted list with scores and rank (top-N marked), (2) a summary in
 - **Never** use `predict()` with the 0.5 threshold as the final result; output is always score → sort → rank.
 - Do not report accuracy or a confusion matrix; evaluate on ranking (AUC, precision@k).
 - Intake (Step 1) always ask first — do not assume; do not hardcode a fixed default algorithm.
-- No neural networks / deep learning.
 - For decisions about people: the list is a prioritisation aid, not a judgement per individual.
 - The user is non-technical: all output and questions to the user are in Dutch; explain choices in plain language, no jargon.

--- a/.claude/skills/voorspellen-ranking/SKILL.md
+++ b/.claude/skills/voorspellen-ranking/SKILL.md
@@ -3,71 +3,72 @@ name: voorspellen-ranking
 description: Bouw risicoscore-modellen (bipartite ranking) die individuen sorteren van hoog naar laag risico, voor situaties met beperkte capaciteit waarin je de top-N selecteert — bijv. een uitnodigingsregel voor studenten met uitvalrisico, prioriteringslijsten, triage, "wie moeten we als eerste benaderen". Gebruik deze skill altijd bij woorden als uitnodigingsregel, risicoscore, risicoprioritering, top-N, ranking op uitval/churn/risico, learning to rank met binaire labels — óók als de gebruiker het "classificatie" noemt maar het doel een gesorteerde lijst is. De ranking-benadering is methodologisch onderbouwd in Eegdeman et al. (2022) en wordt in de praktijk toegepast in de uitnodigingsregel van cedanl; daar blijkt dat sorteren op risicoscore bij beperkte capaciteit betere selecties oplevert dan classificatie met een vaste beslisgrens.
 ---
 
-# Voorspellen: bipartite ranking (risicoscore / uitnodigingsregel)
+# Prediction: bipartite ranking (risk score / uitnodigingsregel)
 
-Doel: geen harde ja/nee-labels, maar een **score per individu** waarmee je sorteert van hoog naar laag risico. Het model is goed als de echte positieven (bijv. uitvallers) bovenaan staan — niet als elke individuele voorspelling "goed" of "fout" is. Evaluatie op rangorde-kwaliteit (AUC, precision@k), niet op accuracy. Klassieke classificatie optimaliseert een beslisgrens bij 0,5 en negeert de volgorde binnen de groepen; voor een lijst met beperkte capaciteit (top-N uitnodigen) wil je juist die volgorde goed hebben. Gebaseerd op cedanl/Uitnodigingsregel (Eegdeman et al., 2022). Verwante termen: learning to rank, AUC optimization.
+Goal: no hard yes/no labels, but a **score per individual** to sort from high to low risk. The model is good when the true positives (e.g. dropouts) are at the top — not when every individual prediction is "right" or "wrong". Evaluated on ranking quality (AUC, precision@k), not on accuracy. Classic classification optimises a decision boundary at 0.5 and ignores the ordering within groups; for a list with limited capacity (invite the top-N) you specifically want that ordering right. Based on cedanl/Uitnodigingsregel (Eegdeman et al., 2022). Related terms: learning to rank, AUC optimization. The user is non-technical: address them in Dutch and keep explanations in plain language.
 
 ## Workflow
 
-When the user invokes `/voorspellen-ranking [optioneel: bestandspad of doelvariabele]`:
+When the user invokes `/voorspellen-ranking [optional: file path or target variable]`:
 
-## Stap 0 — Check: is dit geen tijdreeks-forecasting?
+## Step 0 — Check: is this not time-series forecasting?
 
-Als de vraag is hoe een aantal of percentage zich **over de tijd** ontwikkelt (bijv. "hoeveel uitval verwachten we volgend jaar"), is dat forecasting, geen ranking van individuen — meld dat en gebruik deze skill niet. Deze skill is voor: individuen nu sorteren op risico.
+If the question is how a count or percentage develops **over time** (e.g. "how much dropout do we expect next year"), that is forecasting, not ranking of individuals — say so and do not use this skill. This skill is for: sorting individuals by risk now.
 
-## Stap 1 — Intake (altijd eerst vragen, niet zelf aannemen)
+## Step 1 — Intake (always ask first, do not assume)
 
-1. **Wat is de capaciteit (N of k)?** Hoeveel mensen kunnen er uitgenodigd/behandeld worden? Nodig voor precision@k. Onbekend: rapporteer bij meerdere k's (bijv. 5%, 10%, 20% van de populatie).
-2. **Interpreteerbaar of black box?**
-   - Interpreteerbaar = uitlegbaar waarom iemand hoog scoort (Lasso, logistische regressie). Vaak vereist bij besluiten over studenten.
-   - Black box mag = vaak betere rangorde (Random Forest, Gradient Boosting, XGBoost, SVM). Geen deep learning.
-3. **Instellingen automatisch fijnslijpen of standaardinstellingen?** (vraag het in deze gewone taal, niet met termen als hyperparameters, AUC of grids)
-   - Standaard = snel, prima eerste versie.
-   - Fijnslijpen = het model probeert veel combinaties van instellingen uit en kiest de beste. Duurt langer.
-   - Intern, niet aan de gebruiker voorleggen: tune op scoring="roc_auc" (rangorde, niet accuracy); gebruik standaard de lokale grids uit `references/hyperparameters.md`; alleen als de gebruiker zelf CEDA, de benchmark of vergelijkbaarheid tussen instellingen noemt, de CEDA-grids.
-4. **Meerdere modellen testen en vergelijken, of één aanbeveling volgen?** (in gewone taal vragen)
-   - Vergelijken = aanpak van cedanl/uitnodigingsregel-benchmark: Random Forest, Lasso, SVM, Gradient Boosting, XGBoost naast elkaar, één tabel.
-   - Aanbeveling = beoordeel zelf de case en beveel één algoritme aan met korte motivering. Weeg mee: aantal rijen en features, prevalentie van de positieve klasse, verwachte niet-lineariteit, en de interpretatie-eis uit vraag 2. Geen vaste default hardcoden. Benchmarkresultaten van cedanl mogen als context dienen, niet als automatisch antwoord.
+1. **What is the capacity (N or k)?** How many people can be invited/handled? Needed for precision@k. Unknown: report at multiple k's (e.g. 5%, 10%, 20% of the population).
+2. **Interpretable or black box?**
+   - Interpretable = explainable why someone scores high (Lasso, logistic regression). Often required for decisions about students.
+   - Black box allowed = often better ranking (Random Forest, Gradient Boosting, XGBoost, SVM). No deep learning.
+3. **Automatically fine-tune settings or use default settings?** (ask this in plain language, not with terms like hyperparameters, AUC or grids)
+   - Default = fast, fine first version.
+   - Fine-tune = the model tries many combinations of settings and picks the best. Takes longer.
+   - Internal, do not put to the user: tune on scoring="roc_auc" (ranking, not accuracy); use the local grids from `references/hyperparameters.md` by default; only if the user themselves mentions CEDA, the benchmark or comparability between settings, the CEDA grids.
+4. **Test and compare multiple models, or follow one recommendation?** (ask in plain language)
+   - Compare = the cedanl/uitnodigingsregel-benchmark approach: Random Forest, Lasso, SVM, Gradient Boosting, XGBoost side by side, one table.
+   - Recommendation = assess the case yourself and recommend one algorithm with a short rationale. Weigh: number of rows and features, prevalence of the positive class, expected non-linearity, and the interpretability requirement from question 2. Do not hardcode a fixed default. cedanl benchmark results may serve as context, not as an automatic answer.
 
-## Stap 2 — Data
+## Step 2 — Data
 
-- Binaire doelkolom (bijv. `Dropout` 0/1). Continue doelvariabele → skill `/voorspellen-continu`.
-- Is de data nog niet voorbereid, volg dan eerst de skill `/voorspellen-dataprep` (overzicht, leakage-check, missings, encoding, split).
-- Splits 80/20 stratified (random_state=42) vóór preprocessing; alles in een Pipeline (geen leakage). Als er jaren beschikbaar zijn: liever trainen op eerdere jaren en testen op het laatste jaar (zoals config.yaml in de benchmark: training_years vs dropout_year) — dat lijkt op echt gebruik.
-- Missings imputeren (mediaan/modus), one-hot met handle_unknown="ignore", StandardScaler alleen voor Lasso, logistische regressie en SVM.
-- Klassenonbalans is hier normaal en geen probleem: ranking gebruikt de hele scoreverdeling; niet oversamplen tenzij expliciet gevraagd.
+- Binary target column (e.g. `Dropout` 0/1). Continuous target → skill `/voorspellen-continu`.
+- If the data is not yet prepared, first follow the skill `/voorspellen-dataprep` (overview, leakage check, missings, encoding, split).
+- Split 80/20 stratified (random_state=42) before preprocessing; everything in a Pipeline (no leakage). If years are available: prefer training on earlier years and testing on the most recent year (like config.yaml in the benchmark: training_years vs dropout_year) — this resembles real use.
+- Impute missings (median/mode), one-hot with handle_unknown="ignore", StandardScaler only for Lasso, logistic regression and SVM.
+- Class imbalance is normal here and not a problem: ranking uses the whole score distribution; do not oversample unless explicitly requested.
 
-## Stap 3 — Score maken
+## Step 3 — Producing the score
 
-Twee gangbare routes (cedanl/Uitnodigingsregel gebruikt beide):
-- **Classifier met `predict_proba`**: gebruik de kans op de positieve klasse als score (LogReg, RF-classifier, GB, XGBoost, SVC met probability=True).
-- **Regressor op het 0/1-label**: bijv. Lasso of RandomForestRegressor op de Dropout-kolom; de continue voorspelling is de score.
+Two common routes (cedanl/Uitnodigingsregel uses both):
+- **Classifier with `predict_proba`**: use the probability of the positive class as the score (LogReg, RF classifier, GB, XGBoost, SVC with probability=True).
+- **Regressor on the 0/1 label**: e.g. Lasso or RandomForestRegressor on the Dropout column; the continuous prediction is the score.
 
-Gebruik **nooit** `predict()` met de 0,5-drempel als eindresultaat. De output is altijd: score → sorteren aflopend → rang.
+**Never** use `predict()` with the 0.5 threshold as the final result. The output is always: score → sort descending → rank.
 
-Bij tunen: **scoring="roc_auc"** (bij regressor-route: custom AUC-scorer op de scores). Zoekmethode volgens `references/hyperparameters.md`; niet aan de gebruiker vragen.
+When tuning: **scoring="roc_auc"** (for the regressor route: a custom AUC scorer on the scores). Search method per `references/hyperparameters.md`; do not ask the user.
 
-## Stap 4 — Evaluatie en rapportage
+## Step 4 — Evaluation and reporting
 
-Evalueer op de testset uitsluitend op rangorde-kwaliteit:
-- **AUC (ROC-AUC)**: kans dat een willekeurige positieve boven een willekeurige negatieve staat. 0,5 = random.
-- **Precision@k**: van de top-k op de lijst, welk aandeel is echt positief.
-- **Recall@k**: welk aandeel van alle positieven zit in de top-k.
-- **Precision/recall-curve over alle drempels** (zoals compute_dynamic_evaluation in cedanl/Uitnodigingsregel): cumulatief per rang, van hoogste score naar laagste.
-- Baseline: random ranking (precision@k = prevalentie).
+Evaluate on the test set purely on ranking quality:
+- **AUC (ROC-AUC)**: probability that a random positive ranks above a random negative. 0.5 = random.
+- **Precision@k**: of the top-k on the list, what share is truly positive.
+- **Recall@k**: what share of all positives is in the top-k.
+- **Precision/recall curve across all thresholds** (like compute_dynamic_evaluation in cedanl/Uitnodigingsregel): cumulative per rank, from highest score to lowest.
+- Baseline: random ranking (precision@k = prevalence).
 
-Rapporteer géén accuracy en géén confusion matrix bij drempel 0,5; leg kort uit waarom als de gebruiker erom vraagt.
+Do not report accuracy and do not report a confusion matrix at threshold 0.5; briefly explain why if the user asks.
 
-Bij benchmark: één tabel met AUC en precision@k per algoritme, sorteer op AUC, benoem de winnaar en of het verschil bij de relevante k iets uitmaakt.
+For a benchmark: one table with AUC and precision@k per algorithm, sort by AUC, name the winner and whether the difference matters at the relevant k.
 
-Lever op: (1) gesorteerde lijst met scores en rang (top-N gemarkeerd), (2) samenvatting in gewone taal, (3) herdraaibare code, (4) joblib-model op verzoek. Vermeld bij besluiten over personen dat de lijst een prioriteringshulp is, geen oordeel per individu.
+Deliver: (1) a sorted list with scores and rank (top-N marked), (2) a summary in plain Dutch, (3) reproducible code, (4) a joblib model on request. For decisions about people, state that the list is a prioritisation aid, not a judgement per individual.
 
 ## Important
 
-- Voor top-N selectie bij beperkte capaciteit; harde ja/nee per individu → `/voorspellen-classificatie`, continue uitkomst → `/voorspellen-continu`.
-- Data nog niet voorbereid? Eerst `/voorspellen-dataprep`.
-- Gebruik **nooit** `predict()` met de 0,5-drempel als eindresultaat; output is altijd score → sorteren → rang.
-- Rapporteer géén accuracy of confusion matrix; evalueer op rangorde (AUC, precision@k).
-- Intake (Stap 1) altijd eerst vragen — niet zelf aannemen; geen vast default-algoritme hardcoden.
-- Geen neurale netwerken / deep learning.
-- Bij besluiten over personen: de lijst is een prioriteringshulp, geen oordeel per individu.
+- For top-N selection under limited capacity; hard yes/no per individual → `/voorspellen-classificatie`, continuous outcome → `/voorspellen-continu`.
+- Data not yet prepared? First `/voorspellen-dataprep`.
+- **Never** use `predict()` with the 0.5 threshold as the final result; output is always score → sort → rank.
+- Do not report accuracy or a confusion matrix; evaluate on ranking (AUC, precision@k).
+- Intake (Step 1) always ask first — do not assume; do not hardcode a fixed default algorithm.
+- No neural networks / deep learning.
+- For decisions about people: the list is a prioritisation aid, not a judgement per individual.
+- The user is non-technical: all output and questions to the user are in Dutch; explain choices in plain language, no jargon.

--- a/.claude/skills/voorspellen-ranking/references/hyperparameters.md
+++ b/.claude/skills/voorspellen-ranking/references/hyperparameters.md
@@ -1,6 +1,6 @@
 # Hyperparameter-grids (bipartite ranking)
 
-Tune altijd op rangorde: scoring="roc_auc" (classifier-route) of een custom AUC-scorer op de scores (regressor-route). Zoekmethode (interne keuze, nooit aan de gebruiker vragen): GridSearchCV bij ≤ ~60 combinaties, anders RandomizedSearchCV(n_iter=50). cv=5 (stratified), n_jobs=-1, random_state=42.
+Tune altijd op rangorde: scoring="roc_auc" (classifier-route) of een custom AUC-scorer op de scores (regressor-route). Zoekmethode (default, niet aan de gebruiker vragen, gebruiker mag wel wijzigen): GridSearchCV bij ≤ ~60 combinaties, anders RandomizedSearchCV(n_iter=50). cv=5 (stratified), n_jobs=-1, random_state=42.
 
 Er zijn twee sets. Standaard: set B (lokaal). Set A alleen als de gebruiker zelf CEDA, de benchmark of vergelijkbaarheid tussen instellingen noemt. Geen technische keuzevraag aan de gebruiker stellen.
 

--- a/.claude/skills/voorspellen-ranking/references/hyperparameters.md
+++ b/.claude/skills/voorspellen-ranking/references/hyperparameters.md
@@ -1,0 +1,100 @@
+# Hyperparameter-grids (bipartite ranking)
+
+Tune altijd op rangorde: scoring="roc_auc" (classifier-route) of een custom AUC-scorer op de scores (regressor-route). Zoekmethode (interne keuze, nooit aan de gebruiker vragen): GridSearchCV bij ≤ ~60 combinaties, anders RandomizedSearchCV(n_iter=50). cv=5 (stratified), n_jobs=-1, random_state=42.
+
+Er zijn twee sets. Standaard: set B (lokaal). Set A alleen als de gebruiker zelf CEDA, de benchmark of vergelijkbaarheid tussen instellingen noemt. Geen technische keuzevraag aan de gebruiker stellen.
+
+## A. CEDA-compatibel (exact cedanl/uitnodigingsregel-benchmark models.py) — alleen op expliciete vraag
+
+Gebruik deze uitsluitend als de resultaten vergelijkbaar moeten zijn met andere instellingen of eerdere benchmarkruns. Niet aanpassen (ook de Lasso alpha-range niet: die is bewust afgestemd op 0/1-labels).
+
+```python
+CEDA_GRIDS = {
+    "RandomForest": {
+        "bootstrap": [True, False],
+        "max_depth": [2, 3, 4],
+        "max_features": [3, 4, 5],
+        "min_samples_leaf": [3, 4, 5],
+        "min_samples_split": [2, 3, 5],
+        "n_estimators": [100, 200, 300],
+    },
+    "Lasso": {  # regressor-route op 0/1-label; geschaalde input; max_iter=10_000
+        "alpha": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0,
+                  1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9],
+    },
+    "LogisticRegression": {  # geschaalde input; solver="saga", max_iter=10_000
+        "C": [0.01, 0.1, 1, 10, 100],
+        "penalty": ["elasticnet"],
+        "l1_ratio": [0.0, 0.5, 1.0],
+    },
+    "SVM": {  # geschaalde input; SVC(probability=True)
+        "C": [0.1, 1, 10, 100, 1000],
+        "gamma": [0.0001, 0.001, 0.01, 0.1, 1],
+        "kernel": ["rbf"],
+    },
+    "GradientBoosting": {
+        "n_estimators": [100, 200],
+        "learning_rate": [0.05, 0.1, 0.2],
+        "max_depth": [3, 5, 7],
+        "subsample": [0.8, 1.0],
+    },
+    "XGBoost": {  # eval_metric="logloss", verbosity=0
+        "n_estimators": [100, 200],
+        "learning_rate": [0.05, 0.1, 0.2],
+        "max_depth": [3, 5, 7],
+        "subsample": [0.8, 1.0],
+        "colsample_bytree": [0.8, 1.0],
+    },
+}
+```
+
+Let op bij de CEDA-grids: max_features [3,4,5] en max_depth [2,3,4] passen bij de smalle featuresets van de uitnodigingsregel-context; max_features als int is alleen geldig bij ≥ 5 features.
+
+## B. Lokaal-optimaal (standaard)
+
+Gebruik deze in alle andere gevallen.
+
+```python
+LOCAL_GRIDS = {
+    "RandomForest": {
+        "bootstrap": [True, False],
+        "max_depth": [3, 5, 10, None],
+        "max_features": ["sqrt", "log2", None],
+        "min_samples_leaf": [1, 3, 5],
+        "min_samples_split": [2, 5, 10],
+        "n_estimators": [100, 200, 300],
+    },
+    "Lasso": {  # regressor-route; geschaalde input
+        "alpha": [0.001, 0.005, 0.01, 0.05, 0.1, 0.3, 0.5, 1.0, 1.5],
+        "max_iter": [10_000],
+    },
+    "LogisticRegression": {
+        "C": [0.01, 0.1, 1, 10, 100],
+        "penalty": ["elasticnet"],
+        "l1_ratio": [0.0, 0.5, 1.0],
+    },
+    "SVM": {  # overslaan bij > ~10.000 rijen (te traag)
+        "C": [0.1, 1, 10, 100, 1000],
+        "gamma": ["scale", 0.001, 0.01, 0.1, 1],
+        "kernel": ["rbf"],
+    },
+    "GradientBoosting": {
+        "n_estimators": [100, 200, 400],
+        "learning_rate": [0.02, 0.05, 0.1, 0.2],
+        "max_depth": [2, 3, 5],
+        "subsample": [0.8, 1.0],
+    },
+    "XGBoost": {
+        "n_estimators": [100, 200, 400],
+        "learning_rate": [0.02, 0.05, 0.1, 0.2],
+        "max_depth": [2, 3, 5, 7],
+        "subsample": [0.8, 1.0],
+        "colsample_bytree": [0.8, 1.0],
+    },
+}
+```
+
+Richtlijnen:
+- Lasso op een 0/1-label met alpha ≥ 1 kan alle coëfficiënten naar nul drukken; gebeurt dat, breid de grid naar beneden uit.
+- Optimum op de rand van de grid: die kant uitbreiden en opnieuw zoeken.
+- Grote datasets (> ~50k): cv=3, n_iter=30.


### PR DESCRIPTION
Draft — adds four ML prediction skills under `.claude/skills/`, aimed at non-technical CEDA users who want to build a prediction model from a dataset.

## Skills
- **voorspellen-dataprep** — first step: from raw data to a clean train/test setup in an sklearn Pipeline (overview, route choice, cleaning, leakage check, missings, encoding, split, scaling). Routes to the right follow-up skill.
- **voorspellen-continu** — regression for a continuous/numeric target (grades, EC, amounts).
- **voorspellen-classificatie** — classification for categorical outcomes where each individual prediction counts.
- **voorspellen-ranking** — bipartite ranking / risk score (uitnodigingsregel), sorting individuals for top-N selection under limited capacity; based on cedanl/Uitnodigingsregel (Eegdeman et al., 2022).

Three carry a `references/hyperparameters.md` with tuning grids.

## CEDA conventions
Made conform to `create-skill`:
- `## Workflow` with the `When the user invokes /<naam>` line
- cross-skill references in `/skill-naam` syntax
- `## Important` section per skill
- **body in English, user-facing output in Dutch** (create-skill conventions table, regels 110-111); frontmatter descriptions kept Dutch for trigger matching, and each skill explicitly instructs that all output/questions to the non-technical user are in Dutch

## Notes
- These were installed locally but never committed to the org repo; this promotes them.
- Related: the language-convention ambiguity is tracked in #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)