### PR TITLE
feat: add CEDA app-integration skills (docker, streamlit, surfdrive, etl-pipeline, sram-oidc)

### DIFF
--- a/.claude/skills/docker/SKILL.md
+++ b/.claude/skills/docker/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: docker
+description: Containerize a CEDA app the house way — a uv-based Python image, non-root runtime user, pinned apt packages, and a docker-compose for local dev. Use when adding or editing a Dockerfile / docker-compose.yml in a CEDA repo, or debugging a container build.
+---
+
+# docker
+
+CEDA repos ship a Dockerfile + docker-compose per repo. Match the existing
+conventions (grounded in `text-analysis/Dockerfile` and `docs/gitlab.md`); read
+the target repo's current Dockerfile first.
+
+## Image conventions
+- **Base:** `python:3.12-slim` (multi-arch: `FROM --platform=${BUILDPLATFORM} ...`).
+- **Security updates:** `apt-get update && apt-get -y upgrade`, install only what's
+  needed with `--no-install-recommends`, and **pin apt package versions**
+  (`cron=3.0pl1-162`, …). End the layer with `rm -rf /var/lib/apt/lists/*`.
+- **uv for deps:** copy `pyproject.toml` + `uv.lock`, then `uv sync --frozen --no-dev`.
+  (Older repos `pip install -r requirements.txt`; match what the repo uses.)
+- **Non-root runtime.** Create a user (`useradd -m streamlit`), `chown` what it
+  needs, `USER <name>` before the app runs. Never run the service as root.
+- **Entrypoint** for Streamlit apps: `CMD ["uv", "run", "streamlit", "run", "src/main.py"]`.
+
+## Best practices (from docs/gitlab.md)
+1. Multi-stage builds to shrink the image where it helps.
+2. Combine related `RUN` commands to reduce layers.
+3. Specific version tags on the base image (not `latest`).
+4. Remove build-only deps after use.
+5. Non-root user (see above).
+6. Include a healthcheck (compose or Dockerfile) — Streamlit apps expose `/healthz`.
+
+## Lint before committing
+```bash
+hadolint Dockerfile
+```
+
+## docker-compose (local dev)
+- Env comes from a **`.env`** file (gitignored); compose references
+  `${VAR}` (e.g. `MINIO_*`, `SURFDRIVE_*` — see [[surfdrive]]).
+- Bind-mount `src/` for live editing during dev.
+- Common commands:
+  ```bash
+  docker compose build
+  docker compose up          # -d for detached
+  docker compose down        # -v to drop volumes
+  docker exec -ti <svc> bash # shell in; -u root for maintenance
+  ```
+
+## Honesty
+A local `docker compose up` validates the image builds and starts — it does not
+prove the deployed behavior on SDP (that's Flux/GitLab CI; see [[surf-sdp-helm-flux]]).
+Verify the container actually serves before calling it done.

--- a/.claude/skills/docker/SKILL.md
+++ b/.claude/skills/docker/SKILL.md
@@ -9,6 +9,12 @@ CEDA repos ship a Dockerfile + docker-compose per repo. Match the existing
 conventions (grounded in `text-analysis/Dockerfile` and `docs/gitlab.md`); read
 the target repo's current Dockerfile first.
 
+## When this applies
+
+This is a **knowledge skill** — it loads (explicitly via `/docker`, or
+automatically) when you add or edit a `Dockerfile` / `docker-compose.yml`, or
+debug a container build in a CEDA repo. It is reference/convention.
+
 ## Image conventions
 - **Base:** `python:3.12-slim` (multi-arch: `FROM --platform=${BUILDPLATFORM} ...`).
 - **Security updates:** `apt-get update && apt-get -y upgrade`, install only what's
@@ -35,7 +41,7 @@ hadolint Dockerfile
 
 ## docker-compose (local dev)
 - Env comes from a **`.env`** file (gitignored); compose references
-  `${VAR}` (e.g. `MINIO_*`, `SURFDRIVE_*` — see [[surfdrive]]).
+  `${VAR}` (e.g. `MINIO_*`, `SURFDRIVE_*` — see /surfdrive).
 - Bind-mount `src/` for live editing during dev.
 - Common commands:
   ```bash
@@ -45,7 +51,11 @@ hadolint Dockerfile
   docker exec -ti <svc> bash # shell in; -u root for maintenance
   ```
 
-## Honesty
-A local `docker compose up` validates the image builds and starts — it does not
-prove the deployed behavior on SDP (that's Flux/GitLab CI; see [[surf-sdp-helm-flux]]).
-Verify the container actually serves before calling it done.
+## Important
+- **Match the repo's existing Dockerfile** (uv vs pip, base image) rather than
+  imposing a different toolchain.
+- **Run the service as a non-root user** and pin apt package versions.
+- A local `docker compose up` validates the image builds and starts — it does NOT
+  prove deployed behavior on SDP (that's Flux/GitLab CI; see /surf-sdp-helm-flux).
+  Verify the container actually serves before calling it done.
+- Applies to cedanl repos.

--- a/.claude/skills/docker/SKILL.md
+++ b/.claude/skills/docker/SKILL.md
@@ -6,8 +6,8 @@ description: Containerize a CEDA app the house way — a uv-based Python image, 
 # docker
 
 CEDA repos ship a Dockerfile + docker-compose per repo. Match the existing
-conventions (grounded in `text-analysis/Dockerfile` and `docs/gitlab.md`); read
-the target repo's current Dockerfile first.
+conventions (grounded in the GitLab `text-analysis` repo's `Dockerfile` and its
+`docs/gitlab.md`); read the target repo's current Dockerfile first.
 
 ## When this applies
 

--- a/.claude/skills/etl-pipeline/SKILL.md
+++ b/.claude/skills/etl-pipeline/SKILL.md
@@ -9,10 +9,16 @@ The `instroom-etl-ho` / `instroom-etl-wo` / `instroom-ml` repos share one shape:
 a small, single-purpose **containerized transport step**. Grounded in
 `instroom-etl-ho`.
 
+## When this applies
+
+This is a **knowledge skill** — it loads (explicitly via `/etl-pipeline`, or
+automatically) when you work on `instroom-etl-*` / `instroom-ml` or a similar
+ingest→store pipeline. It is reference/convention.
+
 ## Shape
 ```
 src/transport.py        # entrypoint: ingest → (process) → store
-Dockerfile              # uv-based image (see [[docker]])
+Dockerfile              # uv-based image (see /docker)
 docker-compose.yml      # env wiring + local run
 env.txt / .env          # SURFDRIVE_* + MINIO_* (gitignored for real values)
 ```
@@ -24,7 +30,7 @@ and uploads to MinIO. It exits cleanly (with a message) when no filename is give
 SurfDrive public share  →  download CSV  →  upload to MinIO
    (SURFDRIVE_*)            surfdrive.py       minio_file (account=…)
 ```
-- Ingest: `surfdrive.download_surfdrive_csv(filename)` — see [[surfdrive]].
+- Ingest: `surfdrive.download_surfdrive_csv(filename)` — see /surfdrive.
 - Store: `minio_file.create_connection(account="HO")` + `upload_file(...)`.
 - `instroom-ml` extends this with a modelling step on the stored data.
 
@@ -32,7 +38,7 @@ SurfDrive public share  →  download CSV  →  upload to MinIO
 Compose passes env from `.env`:
 `SURFDRIVE_SHARE_TOKEN`, `SURFDRIVE_PASSWORD`, `MINIO_ACCESS_KEY`,
 `MINIO_SECRET_KEY`, `MINIO_ENDPOINT`, `MINIO_BUCKET`. In deployed environments
-these come from SOPS-encrypted secrets — see [[sdp-secrets-management]].
+these come from SOPS-encrypted secrets — see /sdp-secrets-management.
 
 ## Local dev
 - `docker compose build && docker compose up`; the dev compose often runs
@@ -42,9 +48,15 @@ these come from SOPS-encrypted secrets — see [[sdp-secrets-management]].
 
 ## Deploy
 Built image is deployed via the GitLab/SDP flow (cross-pipeline trigger hands the
-image digest to the config repo). See [[gitlab-ci]] and [[surf-sdp-helm-flux]]
+image digest to the config repo). See /gitlab-ci and /surf-sdp-helm-flux
 (deploy by **image digest**, not floating tags).
 
-## Honesty
-Verify a run actually lands the file in MinIO (list the bucket) before calling it
-done — a silent download failure returns `None`, which the step must raise on.
+## Important
+- **Verify a run actually lands the file in MinIO** (list the bucket) before
+  calling it done — a silent download failure returns `None`, which the step must
+  raise on.
+- Config secrets (`SURFDRIVE_*`, `MINIO_*`) via `.env` locally, SOPS in deployed
+  envs — never commit plaintext (see /sdp-secrets-management).
+- Deploy by **image digest**, not floating tags (see /gitlab-ci,
+  /surf-sdp-helm-flux). Ingest specifics: /surfdrive.
+- Applies to cedanl repos.

--- a/.claude/skills/etl-pipeline/SKILL.md
+++ b/.claude/skills/etl-pipeline/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: etl-pipeline
+description: Build or extend a CEDA instroom-style ETL pipeline — a containerized transport step that pulls source data (e.g. SurfDrive), processes it, and lands it in MinIO, wired via docker-compose env and deployed through the GitLab/SDP flow. Use when working on instroom-etl-* / instroom-ml or a similar ingest→store pipeline.
+---
+
+# etl-pipeline
+
+The `instroom-etl-ho` / `instroom-etl-wo` / `instroom-ml` repos share one shape:
+a small, single-purpose **containerized transport step**. Grounded in
+`instroom-etl-ho`.
+
+## Shape
+```
+src/transport.py        # entrypoint: ingest → (process) → store
+Dockerfile              # uv-based image (see [[docker]])
+docker-compose.yml      # env wiring + local run
+env.txt / .env          # SURFDRIVE_* + MINIO_* (gitignored for real values)
+```
+The transport step takes a filename argument, downloads it from the source,
+and uploads to MinIO. It exits cleanly (with a message) when no filename is given.
+
+## Data flow
+```
+SurfDrive public share  →  download CSV  →  upload to MinIO
+   (SURFDRIVE_*)            surfdrive.py       minio_file (account=…)
+```
+- Ingest: `surfdrive.download_surfdrive_csv(filename)` — see [[surfdrive]].
+- Store: `minio_file.create_connection(account="HO")` + `upload_file(...)`.
+- `instroom-ml` extends this with a modelling step on the stored data.
+
+## Config (docker-compose env)
+Compose passes env from `.env`:
+`SURFDRIVE_SHARE_TOKEN`, `SURFDRIVE_PASSWORD`, `MINIO_ACCESS_KEY`,
+`MINIO_SECRET_KEY`, `MINIO_ENDPOINT`, `MINIO_BUCKET`. In deployed environments
+these come from SOPS-encrypted secrets — see [[sdp-secrets-management]].
+
+## Local dev
+- `docker compose build && docker compose up`; the dev compose often runs
+  `sleep infinity` and bind-mounts `src/` so you `docker exec` in and run the
+  step by hand while iterating.
+- Run the step: `uv run python src/transport.py <filename>`.
+
+## Deploy
+Built image is deployed via the GitLab/SDP flow (cross-pipeline trigger hands the
+image digest to the config repo). See [[gitlab-ci]] and [[surf-sdp-helm-flux]]
+(deploy by **image digest**, not floating tags).
+
+## Honesty
+Verify a run actually lands the file in MinIO (list the bucket) before calling it
+done — a silent download failure returns `None`, which the step must raise on.

--- a/.claude/skills/sram-oidc/SKILL.md
+++ b/.claude/skills/sram-oidc/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: sram-oidc
+description: Add SURF SRAM login (OIDC via the SRAM proxy) to a CEDA app — the authlib OAuth2 flow, the OIDC_* config, and the auth-disabled-by-default fallback used in the CEDA Streamlit apps. Use when wiring SRAM authentication, editing OIDC config, or debugging an SRAM login flow.
+---
+
+# sram-oidc
+
+CEDA apps authenticate users against **SURF SRAM** using standard **OIDC**
+through the SRAM proxy. Grounded in `text-analysis/src/auth.py` +
+`text-analysis/manifests/*/config.yaml`.
+
+## Config (env / ConfigMap)
+```
+OIDC_PROVIDER: SRAM
+OIDC_DISCOVERY_URL: https://proxy.sram.surf.nl/.well-known/openid-configuration
+SERVER_URL: https://<app>.<env>.sdp.surf.nl
+SERVER_REDIRECT:            # optional path appended to SERVER_URL for the callback
+CLIENT_ID / CLIENT_SECRET   # the SRAM OIDC client creds (secret — SOPS)
+```
+- Discovery URL is the SRAM proxy's well-known endpoint; the app reads
+  `authorization_endpoint`, `token_endpoint`, `userinfo_endpoint` from it.
+- `REDIRECT_URI` = `SERVER_URL` + optional `SERVER_REDIRECT`.
+- Scopes: `openid email profile`.
+- `CLIENT_ID`/`CLIENT_SECRET` are **secrets** — store via SOPS
+  ([[sdp-secrets-management]]), never in the ConfigMap or git.
+
+## Flow (authlib + Streamlit)
+Uses `authlib.integrations.requests_client.OAuth2Session`:
+1. **Login page**: fetch discovery, `create_authorization_url(authorization_endpoint, state=…)`,
+   render a "Login with SRAM" link (`target="_self"`).
+2. **Callback** (`?code=…&state=…`): `session.fetch_token(token_endpoint, code=…)`,
+   then GET `userinfo_endpoint` with the bearer token to get the user.
+3. **Session**: user info is packed into a base64 token kept in
+   `st.session_state` and mirrored to a `?session=` query param so it survives
+   refreshes (default 24h). *Note: this token is not signed — it's session
+   continuity, not a security boundary. Don't treat it as tamper-proof.*
+
+## The key convention: auth is opt-in
+`is_auth_enabled()` returns true only when `OIDC_PROVIDER` is set. So:
+- **Local dev / no config → no login** (app runs open). Nothing to stub.
+- Deployed envs set `OIDC_PROVIDER: SRAM` to require login.
+Gate the whole app with one call at the top of `main.py`:
+```python
+from auth import require_authentication
+require_authentication()   # st.stop()s on the login page if not authed
+```
+
+## Debugging
+- "Failed to load OIDC config" → discovery URL unreachable (VPN? typo?).
+- Login loops / no callback → `REDIRECT_URI` must match the client's registered
+  redirect exactly (`SERVER_URL` + `SERVER_REDIRECT`).
+- "not configured properly" → `CLIENT_ID`/`CLIENT_SECRET` missing from env.
+
+## Related
+Lives in the Streamlit frontend ([[streamlit]]); creds via [[sdp-secrets-management]];
+URLs/ingress via [[sdp-onboard]].

--- a/.claude/skills/sram-oidc/SKILL.md
+++ b/.claude/skills/sram-oidc/SKILL.md
@@ -9,6 +9,12 @@ CEDA apps authenticate users against **SURF SRAM** using standard **OIDC**
 through the SRAM proxy. Grounded in `text-analysis/src/auth.py` +
 `text-analysis/manifests/*/config.yaml`.
 
+## When this applies
+
+This is a **knowledge skill** — it loads (explicitly via `/sram-oidc`, or
+automatically) when you wire SRAM authentication, edit `OIDC_*` config, or debug
+an SRAM login flow. It is reference/convention.
+
 ## Config (env / ConfigMap)
 ```
 OIDC_PROVIDER: SRAM
@@ -22,7 +28,7 @@ CLIENT_ID / CLIENT_SECRET   # the SRAM OIDC client creds (secret — SOPS)
 - `REDIRECT_URI` = `SERVER_URL` + optional `SERVER_REDIRECT`.
 - Scopes: `openid email profile`.
 - `CLIENT_ID`/`CLIENT_SECRET` are **secrets** — store via SOPS
-  ([[sdp-secrets-management]]), never in the ConfigMap or git.
+  (/sdp-secrets-management), never in the ConfigMap or git.
 
 ## Flow (authlib + Streamlit)
 Uses `authlib.integrations.requests_client.OAuth2Session`:
@@ -51,6 +57,13 @@ require_authentication()   # st.stop()s on the login page if not authed
   redirect exactly (`SERVER_URL` + `SERVER_REDIRECT`).
 - "not configured properly" → `CLIENT_ID`/`CLIENT_SECRET` missing from env.
 
-## Related
-Lives in the Streamlit frontend ([[streamlit]]); creds via [[sdp-secrets-management]];
-URLs/ingress via [[sdp-onboard]].
+## Important
+- **`CLIENT_ID`/`CLIENT_SECRET` are secrets** — store via SOPS
+  (/sdp-secrets-management), never in the ConfigMap or git.
+- Auth is **opt-in**: no `OIDC_PROVIDER` → app runs open, so local dev needs no
+  login and nothing to stub.
+- The session token is **not signed** — it's session continuity, not a security
+  boundary; don't treat it as tamper-proof.
+- `REDIRECT_URI` must exactly match the client's registered redirect.
+- Lives in the Streamlit frontend (/streamlit); URLs/ingress via /sdp-onboard.
+- Applies to cedanl repos.

--- a/.claude/skills/streamlit/SKILL.md
+++ b/.claude/skills/streamlit/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: streamlit
+description: Build a CEDA Streamlit app the house way — src/ layout with a frontend/ page tree, st.navigation multipage wiring, npuls logo/branding, and uv+Docker packaging. Use when creating a new Streamlit app, adding a page, or structuring the frontend of a CEDA tool.
+---
+
+# streamlit
+
+CEDA Streamlit apps follow a shared shape. Start from `streamlit-template-app`
+for a new app; match the target repo's existing structure when extending one.
+
+## Project layout
+```
+src/
+├── main.py                 # entrypoint: page config, navigation, logo
+├── frontend/               # pages grouped by subdirectory
+│   ├── Overview/Home.py    # (or Home/Home.py)
+│   ├── Files/...
+│   └── Modules/...
+├── backend/                # non-UI logic (file handling, processing)
+├── config/                 # config.yaml + helpers
+└── assets/                 # npuls_logo.png etc.
+```
+
+## Two multipage patterns (match the repo)
+1. **Auto-discovery** (`streamlit-template-app`): `config/screen_scanner.py`
+   provides `get_screens()` + `group_pages_by_subdirectory()`; `main.py` calls
+   `st.navigation(grouped_pages)`. Add a page = drop a `.py` in a `frontend/`
+   subdir; no wiring needed.
+2. **Explicit** (`1cijferho`): `main.py` declares each page with
+   `st.Page("frontend/<Group>/<Page>.py", icon="…", title="…")` and passes the
+   list to `st.navigation([...])`. Add a page = add a `.py` **and** a `st.Page`
+   line.
+
+## main.py essentials
+```python
+st.set_page_config(page_title="CEDA …", page_icon=":material/edit:")
+pg = st.navigation(pages)          # grouped dict or explicit list
+st.logo("src/assets/npuls_logo.png")
+pg.run()
+```
+Global CSS is applied once in `main.py` and shared across pages. For NPULS
+house style, see the `npuls-huisstijl` skill.
+
+## Auth (optional, SRAM)
+Apps gate access with OIDC via SRAM when `OIDC_PROVIDER` is set — wrap the app
+in `require_authentication()`. See [[sram-oidc]]. Auth is disabled cleanly when
+the env vars are absent, so local dev needs no login.
+
+## Packaging & run
+- Deps via **uv** (`pyproject.toml` + `uv.lock`); run `uv run streamlit run src/main.py`.
+- Container + local dev: see [[docker]]. Deploy on SDP: see [[sdp-onboard]],
+  [[surf-sdp-helm-flux]] (Streamlit URL pattern `https://<app>.<env>.sdp.surf.nl`,
+  health probe `/healthz`, ingress port 8501).
+
+## Honesty
+Streamlit UI can't be meaningfully unit-tested headless — run the app and click
+through the golden path before calling a UI change done; say so if you can't.

--- a/.claude/skills/streamlit/SKILL.md
+++ b/.claude/skills/streamlit/SKILL.md
@@ -8,6 +8,12 @@ description: Build a CEDA Streamlit app the house way — src/ layout with a fro
 CEDA Streamlit apps follow a shared shape. Start from `streamlit-template-app`
 for a new app; match the target repo's existing structure when extending one.
 
+## When this applies
+
+This is a **knowledge skill** — it loads (explicitly via `/streamlit`, or
+automatically) when you create a new Streamlit app, add a page, or structure the
+frontend of a CEDA tool. It is reference/convention.
+
 ## Project layout
 ```
 src/
@@ -43,15 +49,20 @@ house style, see the `npuls-huisstijl` skill.
 
 ## Auth (optional, SRAM)
 Apps gate access with OIDC via SRAM when `OIDC_PROVIDER` is set — wrap the app
-in `require_authentication()`. See [[sram-oidc]]. Auth is disabled cleanly when
+in `require_authentication()`. See /sram-oidc. Auth is disabled cleanly when
 the env vars are absent, so local dev needs no login.
 
 ## Packaging & run
 - Deps via **uv** (`pyproject.toml` + `uv.lock`); run `uv run streamlit run src/main.py`.
-- Container + local dev: see [[docker]]. Deploy on SDP: see [[sdp-onboard]],
-  [[surf-sdp-helm-flux]] (Streamlit URL pattern `https://<app>.<env>.sdp.surf.nl`,
+- Container + local dev: see /docker. Deploy on SDP: see /sdp-onboard,
+  /surf-sdp-helm-flux (Streamlit URL pattern `https://<app>.<env>.sdp.surf.nl`,
   health probe `/healthz`, ingress port 8501).
 
-## Honesty
-Streamlit UI can't be meaningfully unit-tested headless — run the app and click
-through the golden path before calling a UI change done; say so if you can't.
+## Important
+- **Match the repo's multipage pattern** (auto-discovery vs explicit `st.Page`);
+  don't mix them.
+- Streamlit UI can't be meaningfully unit-tested headless — run the app and click
+  through the golden path before calling a UI change done; say so if you can't.
+- Auth is **opt-in**: no `OIDC_PROVIDER` → app runs open (fine for local dev).
+  See /sram-oidc. Packaging/deploy: /docker, /sdp-onboard.
+- Applies to cedanl repos.

--- a/.claude/skills/surfdrive/SKILL.md
+++ b/.claude/skills/surfdrive/SKILL.md
@@ -8,11 +8,17 @@ description: Integrate SurfDrive into a CEDA data pipeline — download a CSV fr
 CEDA ETL repos ingest source data from **SurfDrive public shares**. The pattern
 comes from `instroom-etl-ho/src/transport.py`.
 
+## When this applies
+
+This is a **knowledge skill** — it loads (explicitly via `/surfdrive`, or
+automatically) when you wire SurfDrive ingest, set `SURFDRIVE_*` config, or debug
+a SurfDrive download step. It is reference/convention.
+
 ## Config (env vars)
 - `SURFDRIVE_SHARE_TOKEN` — the public-share token (the id in the share URL).
 - `SURFDRIVE_PASSWORD` — the share's password.
 Both are provided via `.env` locally (compose reads `${SURFDRIVE_*}`) and via
-SOPS-encrypted secrets in deployed environments — see [[sdp-secrets-management]].
+SOPS-encrypted secrets in deployed environments — see /sdp-secrets-management.
 Never commit them in plaintext.
 
 ## Usage pattern (transport.py)
@@ -38,6 +44,12 @@ the module's internals (auth mechanism, WebDAV vs public-share API), locate the
 package rather than assuming; this skill covers the *usage contract*
 (`download_surfdrive_csv(filename) -> DataFrame | None`), not its implementation.
 
-## Related
-This ingest step is part of the ETL container flow — see [[etl-pipeline]] and
-[[docker]]. MinIO handoff pairs with the `minio-file` package.
+## Important
+- `SURFDRIVE_SHARE_TOKEN` / `SURFDRIVE_PASSWORD` are **secrets** — never commit in
+  plaintext (SOPS in deployed envs; see /sdp-secrets-management).
+- The `surfdrive`/`minio_file` modules are **not vendored** in the ETL repos —
+  this skill covers the *usage contract* (`download_surfdrive_csv(filename) ->
+  DataFrame | None`), not the implementation. Locate the package for internals.
+- A failed download returns `None` — the step must raise, not proceed silently.
+- Part of the ETL container flow — see /etl-pipeline and /docker.
+- Applies to cedanl repos.

--- a/.claude/skills/surfdrive/SKILL.md
+++ b/.claude/skills/surfdrive/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: surfdrive
+description: Integrate SurfDrive into a CEDA data pipeline — download a CSV from a SurfDrive public share (share token + password) and hand it onward (typically to MinIO). Use when wiring SurfDrive ingest, setting SURFDRIVE_* config, or debugging a SurfDrive download step.
+---
+
+# surfdrive
+
+CEDA ETL repos ingest source data from **SurfDrive public shares**. The pattern
+comes from `instroom-etl-ho/src/transport.py`.
+
+## Config (env vars)
+- `SURFDRIVE_SHARE_TOKEN` — the public-share token (the id in the share URL).
+- `SURFDRIVE_PASSWORD` — the share's password.
+Both are provided via `.env` locally (compose reads `${SURFDRIVE_*}`) and via
+SOPS-encrypted secrets in deployed environments — see [[sdp-secrets-management]].
+Never commit them in plaintext.
+
+## Usage pattern (transport.py)
+```python
+import surfdrive
+import minio_file
+
+df = surfdrive.download_surfdrive_csv(filename)   # pulls from the share
+if df is None:
+    raise Exception(f"Can not download {filename}")
+# ... then push onward, e.g. to MinIO:
+minio = minio_file.create_connection(account="HO")
+minio_file.upload_file(conn=minio, local_path=fullpath, remote_path=filename)
+```
+So the flow is: **SurfDrive share → download CSV → upload to MinIO**. The
+`transport` step takes a filename argument and no-ops (with a message) when none
+is given.
+
+## Note on the `surfdrive` module
+`surfdrive` (and `minio_file`) are imported as packages — they are **not** vendored
+in the ETL repos' source. They're CEDA-internal/external dependencies. If you need
+the module's internals (auth mechanism, WebDAV vs public-share API), locate the
+package rather than assuming; this skill covers the *usage contract*
+(`download_surfdrive_csv(filename) -> DataFrame | None`), not its implementation.
+
+## Related
+This ingest step is part of the ETL container flow — see [[etl-pipeline]] and
+[[docker]]. MinIO handoff pairs with the `minio-file` package.


### PR DESCRIPTION
# Pull Request Description

## Type of Change
- [x] New feature

## Description of Changes
Voegt vijf Claude-skills toe voor het bouwen en integreren van CEDA-apps. Elk is **gegrond in bestaande repos/code**, niet in aannames:

- **docker** — CEDA-containerisatie: uv-based image, non-root runtime user, gepinde apt-packages, `hadolint`, healthcheck, docker-compose voor lokaal. (bron: `text-analysis/Dockerfile` + `docs/gitlab.md`)
- **streamlit** — CEDA Streamlit-app-structuur: `src/` + `frontend/` paginaboom, beide multipage-patronen (`screen_scanner` auto-discovery én expliciete `st.Page`), npuls-logo/branding. (bron: `streamlit-template-app` + `1cijferho`)
- **surfdrive** — SurfDrive public-share ingest (`download_surfdrive_csv` → MinIO), `SURFDRIVE_*` config. (bron: `instroom-etl-ho/src/transport.py`)
- **etl-pipeline** — de instroom-etl transport→MinIO container-vorm, docker-compose env-wiring, deploy per image-digest. (bron: `instroom-etl-ho/wo`, `instroom-ml`)
- **sram-oidc** — SRAM-login via de OIDC-proxy (`proxy.sram.surf.nl`), authlib-flow, auth-opt-in fallback. (bron: `text-analysis/src/auth.py`)

## Related Issues
Vervolg op de skill-PR's #42 (workflow) en #43 (SDP/platform).

## Testing Instructions
- Frontmatter (`name`/`description`) geldig in elke `SKILL.md`.
- Geen machine-specifieke paden.
- Interne `[[skill]]`-verwijzingen: de meeste resolven binnen deze PR; vier verwijzen naar skills uit **PR #43** (`gitlab-ci`, `sdp-onboard`, `surf-sdp-helm-flux`, `sdp-secrets-management`) en resolven zodra #43 gemerged is. Merge #43 vóór (of samen met) deze PR.

## Dependencies
Geen nieuwe. Verwijst naar bestaande tooling/packages (uv, hadolint, authlib, `surfdrive`/`minio_file` interne packages).

## Additional Information
`surfdrive` en `minio_file` zijn CEDA-interne packages, niet gevendord in de ETL-repos — de skill beschrijft het *gebruikscontract*, niet de implementatie.

## Checklist
- [x] My code follows the project's coding standards
- [x] I have updated the documentation accordingly (skills zijn zelf de documentatie)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
