### PR TITLE
docs: add Kennis (knowledge) skill type to create-skill conventions

### DIFF
--- a/.claude/skills/create-skill/SKILL.md
+++ b/.claude/skills/create-skill/SKILL.md
@@ -62,8 +62,16 @@ Op basis van de antwoorden: bepaal het type skill.
 | **Review** | Beoordeelt iets (code, stijl, structuur) | Workflow met criteria-tabellen + bevindingen-format |
 | **Generatie** | Produceert tekst of inhoud (notities, slides, docs) | Workflow met templates + draft → bevestig → publiceer |
 | **Wizard** | Begeleidt door een proces via vragen | Workflow met interview → classificatie → uitvoer |
+| **Kennis** | Legt conventies/feiten vast die Claude's aanpak sturen; geen procedure om uit te voeren | `## When this applies` i.p.v. `## Workflow` (zie hieronder) |
 
 Noteer intern: welk type is dit? Dit bepaalt de structuur van de gegenereerde SKILL.md.
+
+**Actie/Review/Generatie/Wizard** zijn *workflow-skills* — je roept ze aan om een
+procedure uit te voeren. **Kennis** is anders: het is reference/convention die
+Claude meestal **impliciet** laadt (op basis van de `description`) wanneer je in
+dat gebied werkt — bijv. een SDP/Helm-error plakken, of een Dockerfile bewerken.
+Er is geen procedure om te "runnen"; de waarde is dat Claude's volgende actie
+juist is. Forceer bij zo'n skill geen `## Workflow`.
 
 ### 4. Draft de SKILL.md
 
@@ -96,6 +104,33 @@ When the user invokes `/<naam> [optional: ...]`:
 
 ### 2. <Volgende stap>
 ...
+
+## Important
+
+- <Kritieke randvoorwaarden>
+- <Wat de skill expliciet NIET doet>
+```
+
+#### Structuur — kennis-skill
+
+Voor een **Kennis**-skill is er geen procedure. Vervang `## Workflow` door
+`## When this applies` (wanneer/waarom Claude deze kennis laadt) en houd de rest
+van de body als reference (conventies, tabellen, troubleshooting). `## Important`
+blijft verplicht.
+
+```markdown
+# <Naam in plain language>
+
+<2-3 zinnen: welke conventies/feiten legt deze skill vast, en waarom.>
+
+## When this applies
+
+This is a **knowledge skill** — it loads (explicitly via `/<naam>`, or
+automatically) when <situatie waarin de kennis relevant is>. It is
+reference/convention, not a step-by-step procedure.
+
+## <Inhoudelijke secties>
+<conventies, feiten, troubleshooting — de eigenlijke kennis>
 
 ## Important
 


### PR DESCRIPTION
# Pull Request Description

## Type of Change
- [x] Documentation update

## Description of Changes
Voegt een **Kennis**-skilltype toe aan de `create-skill`-conventies.

Uit de review van Steven op #42 kwam naar voren dat niet elke skill een `## Workflow` met "When the user invokes /naam:" past. Skills komen op twee manieren binnen: expliciet (`/naam`) óf **impliciet** — Claude laadt de body automatisch o.b.v. de `description` zodra je vraag matcht. Dat splitst skills in:

- **Workflow-skills** (Actie/Review/Generatie/Wizard) — een procedure die je *uitvoert* → `## Workflow`.
- **Kennis-skills** — conventies/feiten die Claude's *volgende actie* goed maken, meestal impliciet getriggerd (bijv. een Flux-error plakken → juiste fix) → `## When this applies` i.p.v. `## Workflow`.

Concreet toegevoegd aan `create-skill/SKILL.md`:
1. Een **`Kennis`-rij** in de classificatietabel (stap 3).
2. Uitleg van het workflow-vs-kennis-onderscheid.
3. Een **structuur-variant voor kennis-skills** (stap 4) met `## When this applies`; `## Important` blijft verplicht.

## Comparison: Before and After
### Before:
`create-skill` kende alleen workflow-vormige types; alle skills kregen `## Workflow`.

### After:
Kennis-skills hebben een eigen, eerlijke vorm — wat de recent toegevoegde skills (helm, docker, gitlab-ci, sram-oidc, …) al volgen.

## Related Issues
Vervolg op de conventie-alignment in #42, #43, #46.

## Testing Instructions
- Lees `create-skill/SKILL.md`: de `Kennis`-rij + structuur-variant renderen correct.
- Puur documentatie; geen code.

## Dependencies
Geen.

## Checklist
- [x] My code follows the project's coding standards
- [x] I have updated the documentation accordingly
