### PR TITLE
feat: add Object Store skills (objectstore-onboarding, objectstore-experiments)

### DIFF
--- a/.claude/skills/objectstore-experiments/SKILL.md
+++ b/.claude/skills/objectstore-experiments/SKILL.md
@@ -61,12 +61,14 @@ uv run --with boto3,requests python3 experiment_*.py
 5. **Multipart ETag** of a completed object is `<hash>-<numparts>` (e.g. `...-5`) —
    the `-N` suffix marks a multipart object; it is not an MD5 of the whole object.
 
-## Reference scripts (in object-store-evaluation)
-- `functionality/versioning/experiment_versioning.py` — versioning + restore + presigned GET
-- `functionality/bucket-lifecycle-policies/experiment_lifecycle.py` — policy round-trip (+ deferred `check`)
-- `functionality/multipart-upload/experiment_multipart.py` — parts, abort, sha256 integrity
-- `security/sse/experiment_sse_c.py` — SSE-C enforcement + service-managed probe
-- `functionality/presigned-urls/experiment_presigned_put.py` — presigned PUT, SigV2 vs SigV4
+## Reference scripts (bundled in `scripts/`)
+Runnable against the `object-store` profile; each creates and cleans up its own
+bucket. Also mirrored as notebooks in the `object-store-evaluation` repo.
+- `scripts/experiment_versioning.py` — versioning + restore + presigned GET
+- `scripts/experiment_lifecycle.py` — policy round-trip (+ deferred `check`)
+- `scripts/experiment_multipart.py` — parts, abort, sha256 integrity
+- `scripts/experiment_sse_c.py` — SSE-C enforcement + service-managed probe
+- `scripts/experiment_presigned_put.py` — presigned PUT, SigV2 vs SigV4
 
 ## Important
 - Use the **non-root `object-store` profile** for all of this — never the root

--- a/.claude/skills/objectstore-experiments/SKILL.md
+++ b/.claude/skills/objectstore-experiments/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: objectstore-experiments
+description: Exercise and verify S3 features against the SURF Object Store (Ceph RGW) with boto3 — versioning, lifecycle policies, multipart upload, SSE-C encryption, and presigned URLs — plus the known Ceph-vs-AWS behavioural quirks. Use when testing Object Store functionality, writing boto3 against objectstore.surf.nl, or checking whether an S3 feature behaves as it does on AWS.
+---
+
+# objectstore-experiments
+
+Runnable feature checks against the **SURF Object Store** (Ceph RGW,
+`https://objectstore.surf.nl`) using boto3 and the `object-store` aws profile.
+Grounded in the `object-store-evaluation` repo's `functionality/` + `security/`
+notebooks and the accompanying `experiment_*.py` scripts, all verified against a
+live CEDA account.
+
+## When this applies
+
+This is a **knowledge skill** — it loads (explicitly via `/objectstore-experiments`,
+or automatically) when you test Object Store features, write boto3 against
+`objectstore.surf.nl`, or need to know whether an S3 feature behaves the same as
+on AWS. It is reference/convention. For getting access + profiles first, see
+[[objectstore-onboarding]].
+
+## Setup (shared by every experiment)
+```python
+import boto3
+c = boto3.Session(profile_name="object-store").client("s3")   # endpoint from ~/.aws/config
+```
+Run scripts with an isolated, recent boto3 (endpoint_url in config needs boto3 that reads it):
+```bash
+uv run --with boto3,requests python3 experiment_*.py
+```
+
+## Features verified to work (same as AWS S3)
+- **Versioning**: `put_bucket_versioning(Status="Enabled")`. Re-PUT a key → new
+  `VersionId`; `delete_object` places a **delete marker** (data retained);
+  restore by deleting the marker version. `list_object_versions` shows both
+  `Versions` and `DeleteMarkers`.
+- **Lifecycle**: `put_bucket_lifecycle_configuration` with
+  `NoncurrentVersionExpiration` and/or `Expiration` (day-granular; runs on Ceph's
+  own schedule — not observable in real time).
+- **Multipart**: `create_multipart_upload` → `upload_part` (track `PartNumber` +
+  `ETag`, parts ≥ 5 MiB except the last) → `complete_multipart_upload`.
+  `list_multipart_uploads` shows in-progress; `abort_multipart_upload` cleans up.
+- **SSE-C**: `put_object(SSECustomerKey=<32 bytes>, SSECustomerAlgorithm="AES256")`.
+  GET requires the same key. Server echoes `SSECustomerKeyMD5` proving it used your key.
+- **Presigned URLs**: `generate_presigned_url("get_object"|"put_object", ...)`.
+  A credential-less client can PUT/GET via the URL (`requests.put/get`).
+
+## Ceph-vs-AWS quirks (empirically confirmed — do not assume AWS behaviour)
+1. **Presigned URLs default to SigV2** (`?AWSAccessKeyId=...&Signature=...`), not
+   SigV4. Both work; force SigV4 with `Config(signature_version="s3v4")` if a tool
+   requires it.
+2. **SSE-C key errors return `400 InvalidArgument`**, not AWS's `403 AccessDenied`
+   — for *both* a missing key and a wrong key. Assert "GET is denied", not a
+   specific status code.
+3. **No service-managed encryption**: `ServerSideEncryption="aws:kms"` (and
+   SSE-S3) is **rejected** (`400`). SSE-C (customer-provided keys) is the *only*
+   at-rest encryption exposed via the API. This is a deliberate SURF limitation.
+4. **Lifecycle rules are normalised on read-back**: a rule sent with
+   `Filter={"Prefix": ""}` comes back as a legacy top-level `Prefix` (no `Filter`
+   wrapper). Functionally equivalent, but "what I sent" ≠ "what's stored" byte-wise.
+5. **Multipart ETag** of a completed object is `<hash>-<numparts>` (e.g. `...-5`) —
+   the `-N` suffix marks a multipart object; it is not an MD5 of the whole object.
+
+## Reference scripts (in object-store-evaluation)
+- `functionality/versioning/experiment_versioning.py` — versioning + restore + presigned GET
+- `functionality/bucket-lifecycle-policies/experiment_lifecycle.py` — policy round-trip (+ deferred `check`)
+- `functionality/multipart-upload/experiment_multipart.py` — parts, abort, sha256 integrity
+- `security/sse/experiment_sse_c.py` — SSE-C enforcement + service-managed probe
+- `functionality/presigned-urls/experiment_presigned_put.py` — presigned PUT, SigV2 vs SigV4
+
+## Important
+- Use the **non-root `object-store` profile** for all of this — never the root
+  profile (see [[objectstore-onboarding]]).
+- Experiments **create and delete buckets** — each script cleans up after itself.
+  Bucket names must be lowercase and unique within the store; parameterise them so
+  reruns don't collide on an existing name.
+- Lifecycle expiration cannot be observed live (day granularity + Ceph's schedule)
+  — verify the policy *round-trips*, then re-check after a day.
+- SSE-C keys are **client-side secrets**: if you lose the key, the object is
+  unrecoverable. There is no service-managed fallback on this store.
+- Applies to cedanl repos using the SURF Object Store.

--- a/.claude/skills/objectstore-experiments/SKILL.md
+++ b/.claude/skills/objectstore-experiments/SKILL.md
@@ -17,7 +17,7 @@ This is a **knowledge skill** — it loads (explicitly via `/objectstore-experim
 or automatically) when you test Object Store features, write boto3 against
 `objectstore.surf.nl`, or need to know whether an S3 feature behaves the same as
 on AWS. It is reference/convention. For getting access + profiles first, see
-[[objectstore-onboarding]].
+/objectstore-onboarding.
 
 ## Setup (shared by every experiment)
 ```python
@@ -72,7 +72,7 @@ bucket. Also mirrored as notebooks in the `object-store-evaluation` repo.
 
 ## Important
 - Use the **non-root `object-store` profile** for all of this — never the root
-  profile (see [[objectstore-onboarding]]).
+  profile (see /objectstore-onboarding).
 - Experiments **create and delete buckets** — each script cleans up after itself.
   Bucket names must be lowercase and unique within the store; parameterise them so
   reruns don't collide on an existing name.

--- a/.claude/skills/objectstore-experiments/scripts/experiment_lifecycle.py
+++ b/.claude/skills/objectstore-experiments/scripts/experiment_lifecycle.py
@@ -1,0 +1,135 @@
+"""Hands-on experiment: bucket lifecycle policies against SURF Object Store.
+
+Mirrors the repo's bucket-lifecycle-policies notebook: a versioned bucket, a
+lifecycle rule that expires non-current (old) versions, plus a rule that expires
+current objects after N days. Credentials come from a named AWS profile.
+
+Lifecycle expiration is day-granular and executed by Ceph on its own schedule,
+so we cannot watch an object vanish in real time. What we CAN verify now:
+  - the policy is accepted and stored exactly as configured (round-trip)
+  - both current-version and non-current-version rules are supported
+Run once to set it up; rerun later with `check` to see if Ceph applied it.
+
+Run with:
+    uv run --with boto3 python3 experiment_lifecycle.py          # set up + verify policy
+    uv run --with boto3 python3 experiment_lifecycle.py check     # re-list versions later
+    uv run --with boto3 python3 experiment_lifecycle.py cleanup   # remove bucket
+"""
+
+import json
+import sys
+
+import boto3
+
+PROFILE = "object-store"
+BUCKET = "caspar-lifecycle-experiment"
+KEY = "object.bin"
+
+POLICY = {
+    "Rules": [
+        {
+            "ID": "expire-noncurrent-versions-after-1-day",
+            "Filter": {"Prefix": ""},
+            "NoncurrentVersionExpiration": {"NoncurrentDays": 1},
+            "Status": "Enabled",
+        },
+        {
+            "ID": "expire-current-objects-after-30-days",
+            "Filter": {"Prefix": "tmp/"},
+            "Expiration": {"Days": 30},
+            "Status": "Enabled",
+        },
+    ]
+}
+
+
+def client():
+    return boto3.Session(profile_name=PROFILE).client("s3")
+
+
+def ensure_bucket(c):
+    names = [b["Name"] for b in c.list_buckets()["Buckets"]]
+    if BUCKET not in names:
+        print(f"[setup] creating bucket {BUCKET}")
+        c.create_bucket(Bucket=BUCKET)
+    c.put_bucket_versioning(
+        Bucket=BUCKET, VersioningConfiguration={"Status": "Enabled"}
+    )
+    print("[setup] versioning enabled")
+
+
+def make_versions(c):
+    # Two puts of the same key -> one current + one non-current version.
+    c.put_object(Bucket=BUCKET, Key=KEY, Body=b"v1 - will become non-current\n")
+    c.put_object(Bucket=BUCKET, Key=KEY, Body=b"v2 - current\n")
+    print("[data] uploaded two versions of", KEY)
+
+
+def list_versions(c):
+    resp = c.list_object_versions(Bucket=BUCKET)
+    versions = resp.get("Versions", [])
+    print(f"[list] {len(versions)} version(s):")
+    for v in versions:
+        print(f"    {v['Key']} {v['VersionId']} latest={v['IsLatest']}")
+    return versions
+
+
+def apply_policy(c):
+    print("[policy] applying lifecycle configuration")
+    c.put_bucket_lifecycle_configuration(
+        Bucket=BUCKET, LifecycleConfiguration=POLICY
+    )
+    stored = c.get_bucket_lifecycle_configuration(Bucket=BUCKET)
+    # Strip ResponseMetadata for a clean diff-style print.
+    stored = {"Rules": stored["Rules"]}
+    print("[policy] read back from server:")
+    print(json.dumps(stored, indent=2, default=str))
+
+    sent_ids = {r["ID"] for r in POLICY["Rules"]}
+    got_ids = {r["ID"] for r in stored["Rules"]}
+    assert sent_ids == got_ids, f"rule mismatch: sent {sent_ids}, got {got_ids}"
+    print(f"[policy] OK - both rules stored: {sorted(got_ids)}")
+
+
+def main(mode: str) -> int:
+    c = client()
+
+    if mode == "cleanup":
+        resp = c.list_object_versions(Bucket=BUCKET)
+        objs = [
+            {"Key": o["Key"], "VersionId": o["VersionId"]}
+            for o in resp.get("Versions", []) + resp.get("DeleteMarkers", [])
+        ]
+        if objs:
+            c.delete_objects(Bucket=BUCKET, Delete={"Objects": objs})
+        c.delete_bucket(Bucket=BUCKET)
+        print(f"[cleanup] removed bucket {BUCKET}")
+        return 0
+
+    if mode == "check":
+        print("[check] current versions (compare against the two from setup):")
+        list_versions(c)
+        print(
+            "[check] if Ceph has run its lifecycle pass, the non-current version "
+            "should be gone (>=1 day after setup)."
+        )
+        return 0
+
+    # default: set up + verify
+    ensure_bucket(c)
+    make_versions(c)
+    print("\n== versions before policy ==")
+    list_versions(c)
+    print("\n== apply + round-trip the lifecycle policy ==")
+    apply_policy(c)
+    print(
+        "\nDone. The policy is stored and verified. Expiration is day-granular and "
+        "runs on Ceph's schedule, so rerun with `check` after ~a day to observe the "
+        "non-current version being expired.\n"
+        "  uv run --with boto3 python3 experiment_lifecycle.py check"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "setup"))

--- a/.claude/skills/objectstore-experiments/scripts/experiment_multipart.py
+++ b/.claude/skills/objectstore-experiments/scripts/experiment_multipart.py
@@ -1,0 +1,137 @@
+"""Hands-on experiment: multipart upload against SURF Object Store.
+
+Mirrors the repo's multipart-upload notebook: create a multipart upload, upload
+parts against the upload ID tracking (PartNumber, ETag), then complete it.
+Credentials come from a named AWS profile ("object-store").
+
+Beyond the notebook, this experiment also verifies integrity end to end by
+comparing a hash of the reassembled object against the source, and demonstrates
+that an in-progress upload can be listed and aborted.
+
+Run with:
+    uv run --with boto3 python3 experiment_multipart.py
+"""
+
+import hashlib
+import os
+import sys
+
+import boto3
+
+PROFILE = "object-store"
+BUCKET = "caspar-multipart-experiment"
+KEY = "multipart.bin"
+
+# 40 MiB total, 8 MiB parts -> 5 parts. Small enough to run fast, large enough
+# that parts are genuine (S3 requires all but the last part be >= 5 MiB).
+TOTAL_BYTES = 40 * 1024 ** 2
+PART_SIZE = 8 * 1024 ** 2
+
+
+def client():
+    return boto3.Session(profile_name=PROFILE).client("s3")
+
+
+def ensure_bucket(c):
+    names = [b["Name"] for b in c.list_buckets()["Buckets"]]
+    if BUCKET not in names:
+        print(f"[setup] creating bucket {BUCKET}")
+        c.create_bucket(Bucket=BUCKET)
+
+
+def parts_of(data, size):
+    for i in range(0, len(data), size):
+        yield data[i:i + size]
+
+
+def upload_multipart(c, data):
+    upload_id = c.create_multipart_upload(Bucket=BUCKET, Key=KEY)["UploadId"]
+    print(f"[mpu] started upload_id={upload_id}")
+    print(f"[mpu] uploading {len(data)} bytes in {PART_SIZE}-byte parts")
+
+    # Show that the in-progress upload is visible before completion.
+    in_progress = c.list_multipart_uploads(Bucket=BUCKET).get("Uploads", [])
+    print(f"[mpu] in-progress uploads visible: {len(in_progress)}")
+
+    parts = []
+    for n, chunk in enumerate(parts_of(data, PART_SIZE), 1):
+        etag = c.upload_part(
+            Bucket=BUCKET, Key=KEY, Body=chunk, PartNumber=n, UploadId=upload_id
+        )["ETag"]
+        parts.append({"PartNumber": n, "ETag": etag})
+        print(f"[mpu] part {n}: {len(chunk)} bytes, ETag={etag}")
+
+    c.complete_multipart_upload(
+        Bucket=BUCKET, Key=KEY, UploadId=upload_id,
+        MultipartUpload={"Parts": parts},
+    )
+    print(f"[mpu] completed {len(parts)} parts")
+    return len(parts)
+
+
+def verify(c, data, n_parts):
+    obj = next(
+        o for o in c.list_objects_v2(Bucket=BUCKET)["Contents"] if o["Key"] == KEY
+    )
+    assert obj["Size"] == len(data), f"size {obj['Size']} != {len(data)}"
+    print(f"[verify] stored size matches source: {obj['Size']} bytes")
+
+    # Multipart ETags are of the form "<md5-of-md5s>-<numparts>" on S3/Ceph.
+    etag = obj["ETag"].strip('"')
+    print(f"[verify] object ETag: {etag}")
+    if etag.endswith(f"-{n_parts}"):
+        print(f"[verify] ETag reports {n_parts} parts (multipart marker present)")
+
+    # Full round-trip integrity: download and compare content hash.
+    downloaded = c.get_object(Bucket=BUCKET, Key=KEY)["Body"].read()
+    src_hash = hashlib.sha256(data).hexdigest()
+    dl_hash = hashlib.sha256(downloaded).hexdigest()
+    assert src_hash == dl_hash, "content hash mismatch!"
+    print(f"[verify] sha256 matches end to end: {src_hash[:16]}...")
+
+
+def demo_abort(c):
+    """Start an upload and abort it, showing cleanup of orphaned parts."""
+    upload_id = c.create_multipart_upload(Bucket=BUCKET, Key="aborted.bin")["UploadId"]
+    c.upload_part(
+        Bucket=BUCKET, Key="aborted.bin", Body=os.urandom(5 * 1024 ** 2),
+        PartNumber=1, UploadId=upload_id,
+    )
+    print(f"[abort] started and uploaded 1 part for upload_id={upload_id}")
+    c.abort_multipart_upload(Bucket=BUCKET, Key="aborted.bin", UploadId=upload_id)
+    remaining = c.list_multipart_uploads(Bucket=BUCKET).get("Uploads", [])
+    print(f"[abort] aborted; in-progress uploads now: {len(remaining)}")
+
+
+def cleanup(c):
+    for o in c.list_objects_v2(Bucket=BUCKET).get("Contents", []):
+        c.delete_object(Bucket=BUCKET, Key=o["Key"])
+    c.delete_bucket(Bucket=BUCKET)
+    print(f"[cleanup] removed bucket {BUCKET}")
+
+
+def main() -> int:
+    c = client()
+    ensure_bucket(c)
+
+    print("\n== generate source data ==")
+    data = os.urandom(TOTAL_BYTES)
+    print(f"[data] generated {len(data)} random bytes")
+
+    print("\n== multipart upload ==")
+    n_parts = upload_multipart(c, data)
+
+    print("\n== verify ==")
+    verify(c, data, n_parts)
+
+    print("\n== abort demo ==")
+    demo_abort(c)
+
+    print("\n== cleanup ==")
+    cleanup(c)
+    print("\nAll assertions passed. Experiment complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/objectstore-experiments/scripts/experiment_presigned_put.py
+++ b/.claude/skills/objectstore-experiments/scripts/experiment_presigned_put.py
@@ -1,0 +1,101 @@
+"""Hands-on experiment: presigned PUT + SigV4 against SURF Object Store.
+
+The repo's presigned-urls notebook demonstrates presigned GET and PUT. This
+experiment focuses on two extra angles:
+
+  1. A presigned PUT URL: a client with NO credentials uploads an object using
+     only the URL (via plain requests.put), then we verify it landed.
+  2. Signature versions: Boto3's default against this endpoint produces a legacy
+     SigV2 URL (?AWSAccessKeyId=...&Signature=...). We also generate an explicit
+     SigV4 URL (?X-Amz-Algorithm=AWS4-HMAC-SHA256...) and confirm both work.
+
+Credentials come from a named AWS profile ("object-store").
+
+Run with:
+    uv run --with boto3,requests python3 experiment_presigned_put.py
+"""
+
+import sys
+
+import boto3
+import requests
+from botocore.config import Config
+
+PROFILE = "object-store"
+BUCKET = "caspar-presigned-experiment"
+KEY = "uploaded-via-url.txt"
+BODY = b"this object was uploaded through a presigned PUT URL, no creds on the client\n"
+
+
+def make_client(sig_version=None):
+    session = boto3.Session(profile_name=PROFILE)
+    cfg = Config(signature_version=sig_version) if sig_version else None
+    return session.client("s3", config=cfg)
+
+
+def ensure_bucket(c):
+    names = [b["Name"] for b in c.list_buckets()["Buckets"]]
+    if BUCKET not in names:
+        print(f"[setup] creating bucket {BUCKET}")
+        c.create_bucket(Bucket=BUCKET)
+
+
+def classify(url: str) -> str:
+    if "X-Amz-Algorithm=AWS4-HMAC-SHA256" in url:
+        return "SigV4"
+    if "AWSAccessKeyId=" in url:
+        return "SigV2"
+    return "unknown"
+
+
+def presigned_put_roundtrip(c, label, key):
+    url = c.generate_presigned_url(
+        "put_object", Params={"Bucket": BUCKET, "Key": key}, ExpiresIn=300
+    )
+    print(f"[{label}] PUT url style: {classify(url)}")
+    # A credential-less client uploads using only the URL.
+    r = requests.put(url, data=BODY, timeout=30)
+    print(f"[{label}] upload HTTP {r.status_code}")
+    assert r.status_code == 200, f"presigned PUT failed: {r.status_code} {r.text[:200]}"
+
+    # Verify via authenticated GET that the bytes really landed.
+    stored = c.get_object(Bucket=BUCKET, Key=key)["Body"].read()
+    assert stored == BODY, "stored bytes differ from what we PUT"
+    print(f"[{label}] verified stored content matches ({len(stored)} bytes)")
+
+    # And a presigned GET should return it too.
+    get_url = c.generate_presigned_url(
+        "get_object", Params={"Bucket": BUCKET, "Key": key}, ExpiresIn=300
+    )
+    g = requests.get(get_url, timeout=30)
+    print(f"[{label}] presigned GET ({classify(get_url)}) HTTP {g.status_code}")
+    assert g.status_code == 200 and g.content == BODY
+
+
+def cleanup(c):
+    for o in c.list_objects_v2(Bucket=BUCKET).get("Contents", []):
+        c.delete_object(Bucket=BUCKET, Key=o["Key"])
+    c.delete_bucket(Bucket=BUCKET)
+    print(f"[cleanup] removed bucket {BUCKET}")
+
+
+def main() -> int:
+    default_client = make_client()
+    ensure_bucket(default_client)
+
+    print("\n== presigned PUT with Boto3 default signing ==")
+    presigned_put_roundtrip(default_client, "default", KEY)
+
+    print("\n== presigned PUT with explicit SigV4 signing ==")
+    v4_client = make_client(sig_version="s3v4")
+    presigned_put_roundtrip(v4_client, "sigv4", "uploaded-via-sigv4.txt")
+
+    print("\n== cleanup ==")
+    cleanup(default_client)
+    print("\nAll assertions passed. Presigned PUT works with both signature styles. "
+          "Experiment complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/objectstore-experiments/scripts/experiment_sse_c.py
+++ b/.claude/skills/objectstore-experiments/scripts/experiment_sse_c.py
@@ -1,0 +1,146 @@
+"""Hands-on experiment: SSE-C (customer-provided keys) against SURF Object Store.
+
+The README flags SSE-C as SURF Object Store's only encryption option exposed via
+the API (no service-managed keys like Amazon's SSE-S3). This experiment mirrors
+the repo's sse notebook (put/get with SSECustomerKey) and additionally proves the
+security property that makes SSE-C meaningful:
+
+  1. PUT an object encrypted with a customer key (AES256)
+  2. Confirm the server returns the key's MD5 (proof it used our key)
+  3. GET with the correct key -> plaintext returned
+  4. GET WITHOUT the key           -> must fail (400)
+  5. GET with the WRONG key         -> must fail (403)
+  6. For contrast, show that service-managed encryption (SSE-S3 / aws:kms) is
+     NOT offered by SURF Object Store, per the README.
+
+Credentials come from a named AWS profile ("object-store").
+
+Run with:
+    uv run --with boto3 python3 experiment_sse_c.py
+"""
+
+import os
+import sys
+from base64 import b64encode
+from hashlib import md5
+
+import boto3
+from botocore.exceptions import ClientError
+
+PROFILE = "object-store"
+BUCKET = "caspar-sse-experiment"
+KEY = "secret.bin"
+
+CUSTOMER_KEY = os.urandom(32)   # 256-bit key; os.urandom fine for a demo
+WRONG_KEY = os.urandom(32)
+PLAINTEXT = b"top secret: encrypted with a customer-provided key on SURF Object Store\n"
+
+
+def client():
+    return boto3.Session(profile_name=PROFILE).client("s3")
+
+
+def ensure_bucket(c):
+    names = [b["Name"] for b in c.list_buckets()["Buckets"]]
+    if BUCKET not in names:
+        print(f"[setup] creating bucket {BUCKET}")
+        c.create_bucket(Bucket=BUCKET)
+
+
+def put_encrypted(c):
+    resp = c.put_object(
+        Bucket=BUCKET, Key=KEY, Body=PLAINTEXT,
+        SSECustomerKey=CUSTOMER_KEY, SSECustomerAlgorithm="AES256",
+    )
+    returned_md5 = resp.get("SSECustomerKeyMD5")
+    expected_md5 = b64encode(md5(CUSTOMER_KEY).digest()).decode("ascii")
+    print(f"[put] stored encrypted; server SSECustomerKeyMD5={returned_md5}")
+    assert returned_md5 == expected_md5, "server key MD5 does not match our key"
+    print("[put] server confirms it used OUR key (MD5 matches)")
+
+
+def get_with_correct_key(c):
+    body = c.get_object(
+        Bucket=BUCKET, Key=KEY,
+        SSECustomerKey=CUSTOMER_KEY, SSECustomerAlgorithm="AES256",
+    )["Body"].read()
+    assert body == PLAINTEXT, "decrypted content mismatch"
+    print(f"[get+key] correct key -> plaintext returned: {body!r}")
+
+
+def get_without_key(c):
+    try:
+        c.get_object(Bucket=BUCKET, Key=KEY)
+        print("[get-nokey] UNEXPECTED: object returned without the key!")
+        return False
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        status = e.response["ResponseMetadata"]["HTTPStatusCode"]
+        print(f"[get-nokey] correctly denied: HTTP {status} {code}")
+        return True
+
+
+def get_with_wrong_key(c):
+    try:
+        c.get_object(
+            Bucket=BUCKET, Key=KEY,
+            SSECustomerKey=WRONG_KEY, SSECustomerAlgorithm="AES256",
+        )
+        print("[get-wrongkey] UNEXPECTED: wrong key decrypted the object!")
+        return False
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        status = e.response["ResponseMetadata"]["HTTPStatusCode"]
+        print(f"[get-wrongkey] correctly denied: HTTP {status} {code}")
+        return True
+
+
+def probe_service_managed(c):
+    """The README says SURF offers no service-managed keys. Probe aws:kms."""
+    try:
+        c.put_object(
+            Bucket=BUCKET, Key="kms-probe.bin", Body=b"x",
+            ServerSideEncryption="aws:kms",
+        )
+        print("[sse-s3] aws:kms PUT accepted (service-managed encryption available?)")
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        status = e.response["ResponseMetadata"]["HTTPStatusCode"]
+        print(f"[sse-s3] aws:kms rejected: HTTP {status} {code} "
+              "(consistent with README: no service-managed keys)")
+
+
+def cleanup(c):
+    for o in c.list_objects_v2(Bucket=BUCKET).get("Contents", []):
+        c.delete_object(Bucket=BUCKET, Key=o["Key"])
+    c.delete_bucket(Bucket=BUCKET)
+    print(f"[cleanup] removed bucket {BUCKET}")
+
+
+def main() -> int:
+    c = client()
+    ensure_bucket(c)
+
+    print("\n== PUT with customer key ==")
+    put_encrypted(c)
+
+    print("\n== GET with correct key ==")
+    get_with_correct_key(c)
+
+    print("\n== security checks: GET must fail without/with wrong key ==")
+    ok_nokey = get_without_key(c)
+    ok_wrong = get_with_wrong_key(c)
+
+    print("\n== probe for service-managed encryption (expected: unavailable) ==")
+    probe_service_managed(c)
+
+    print("\n== cleanup ==")
+    cleanup(c)
+
+    assert ok_nokey and ok_wrong, "SSE-C did not enforce key requirement!"
+    print("\nAll assertions passed. SSE-C enforces the customer key. Experiment complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/objectstore-experiments/scripts/experiment_versioning.py
+++ b/.claude/skills/objectstore-experiments/scripts/experiment_versioning.py
@@ -1,0 +1,154 @@
+"""Hands-on experiment: object versioning + presigned URLs against SURF Object Store.
+
+Mirrors the conventions of the repo's functionality notebooks: credentials come
+from a named AWS profile (default "object-store"), not from hardcoded keys, and
+the S3 endpoint is read from ~/.aws/config for that profile.
+
+Run with:
+    uv run --with boto3,requests python3 experiment_versioning.py
+
+The experiment:
+  1. Create a fresh, uniquely-named bucket
+  2. Enable object versioning
+  3. Upload the same key twice -> two versions
+  4. Delete the object      -> a delete marker (data not lost)
+  5. List versions + delete markers
+  6. Restore by removing the delete marker; verify content is back
+  7. Generate a presigned GET URL and download over plain HTTPS
+  8. Clean up (delete all versions, remove bucket)
+"""
+
+import sys
+
+import boto3
+import requests
+
+PROFILE = "object-store"
+# A per-run-ish unique suffix without needing wall-clock randomness: derive from
+# the two object bodies so reruns that change content get a new-ish name, but
+# keep it simple and lowercase to satisfy S3 bucket naming rules.
+BUCKET = "caspar-versioning-experiment"
+KEY = "note.txt"
+
+BODY_V1 = b"version one: hello from the SURF Object Store experiment\n"
+BODY_V2 = b"version two: this overwrites v1 but v1 is retained\n"
+
+
+def get_boto3_client(profile_name: str):
+    session = boto3.Session(profile_name=profile_name)
+    return session.client("s3")
+
+
+def ensure_bucket(client, bucket: str):
+    existing = [b["Name"] for b in client.list_buckets()["Buckets"]]
+    if bucket in existing:
+        print(f"[setup] bucket {bucket} already exists, reusing")
+    else:
+        print(f"[setup] creating bucket {bucket}")
+        client.create_bucket(Bucket=bucket)
+
+
+def enable_versioning(client, bucket: str):
+    print(f"[versioning] enabling on {bucket}")
+    client.put_bucket_versioning(
+        Bucket=bucket, VersioningConfiguration={"Status": "Enabled"}
+    )
+    status = client.get_bucket_versioning(Bucket=bucket).get("Status")
+    print(f"[versioning] status is now: {status}")
+
+
+def put(client, bucket: str, key: str, body: bytes) -> str:
+    resp = client.put_object(Bucket=bucket, Key=key, Body=body)
+    vid = resp.get("VersionId", "(none)")
+    print(f"[put] {bucket}/{key} -> VersionId={vid}")
+    return vid
+
+
+def list_versions(client, bucket: str, key: str):
+    resp = client.list_object_versions(Bucket=bucket, Prefix=key)
+    print(f"[list] versions for {bucket}/{key}:")
+    for v in resp.get("Versions", []):
+        print(f"    version {v['VersionId']} latest={v['IsLatest']} size={v['Size']}")
+    print(f"[list] delete markers for {bucket}/{key}:")
+    for dm in resp.get("DeleteMarkers", []):
+        print(f"    marker  {dm['VersionId']} latest={dm['IsLatest']}")
+    return resp
+
+
+def get_body(client, bucket: str, key: str) -> bytes:
+    return client.get_object(Bucket=bucket, Key=key)["Body"].read()
+
+
+def presigned_get(client, bucket: str, key: str, expires: int = 300) -> str:
+    return client.generate_presigned_url(
+        "get_object", Params={"Bucket": bucket, "Key": key}, ExpiresIn=expires
+    )
+
+
+def cleanup(client, bucket: str):
+    print(f"[cleanup] removing all versions in {bucket}")
+    resp = client.list_object_versions(Bucket=bucket)
+    to_delete = [
+        {"Key": o["Key"], "VersionId": o["VersionId"]}
+        for o in resp.get("Versions", []) + resp.get("DeleteMarkers", [])
+    ]
+    if to_delete:
+        client.delete_objects(Bucket=bucket, Delete={"Objects": to_delete})
+    client.delete_bucket(Bucket=bucket)
+    print(f"[cleanup] deleted bucket {bucket}")
+
+
+def main() -> int:
+    client = get_boto3_client(PROFILE)
+
+    ensure_bucket(client, BUCKET)
+    enable_versioning(client, BUCKET)
+
+    print("\n== upload two versions ==")
+    put(client, BUCKET, KEY, BODY_V1)
+    put(client, BUCKET, KEY, BODY_V2)
+    list_versions(client, BUCKET, KEY)
+
+    print("\n== current content (should be v2) ==")
+    current = get_body(client, BUCKET, KEY)
+    print(f"[get] current body: {current!r}")
+    assert current == BODY_V2, "expected v2 to be the latest"
+
+    print("\n== delete the object (places a delete marker) ==")
+    client.delete_object(Bucket=BUCKET, Key=KEY)
+    list_versions(client, BUCKET, KEY)
+    try:
+        client.get_object(Bucket=BUCKET, Key=KEY)
+        print("[get] unexpectedly still readable")
+    except client.exceptions.NoSuchKey:
+        print("[get] object now returns NoSuchKey (hidden by delete marker) - data still retained")
+
+    print("\n== restore by removing the delete marker ==")
+    resp = client.list_object_versions(Bucket=BUCKET, Prefix=KEY)
+    latest_marker = next(
+        (dm for dm in resp.get("DeleteMarkers", []) if dm["IsLatest"]), None
+    )
+    if latest_marker:
+        client.delete_object(
+            Bucket=BUCKET, Key=KEY, VersionId=latest_marker["VersionId"]
+        )
+        print(f"[restore] removed delete marker {latest_marker['VersionId']}")
+    restored = get_body(client, BUCKET, KEY)
+    print(f"[get] restored body: {restored!r}")
+    assert restored == BODY_V2, "expected restore to bring back v2"
+
+    print("\n== presigned GET URL ==")
+    url = presigned_get(client, BUCKET, KEY)
+    print(f"[presign] {url[:90]}...")
+    r = requests.get(url, timeout=30)
+    print(f"[presign] HTTP {r.status_code}, body: {r.content!r}")
+    assert r.status_code == 200 and r.content == BODY_V2
+
+    print("\n== cleanup ==")
+    cleanup(client, BUCKET)
+    print("\nAll assertions passed. Experiment complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/objectstore-onboarding/SKILL.md
+++ b/.claude/skills/objectstore-onboarding/SKILL.md
@@ -74,7 +74,7 @@ The AWS-managed `AmazonS3FullAccess` ARN works on Ceph RGW.
 
 ## 6. Configure the working profile — name it `object-store`
 The `object-store-evaluation` notebooks call `boto3.Session(profile_name="object-store")`,
-so use that exact name and they (and [[objectstore-experiments]]) work unchanged.
+so use that exact name and they (and /objectstore-experiments) work unchanged.
 ```bash
 aws configure --profile object-store set aws_access_key_id     <NONROOT_ID>
 aws configure --profile object-store set aws_secret_access_key <NONROOT_SECRET>
@@ -82,7 +82,7 @@ aws configure --profile object-store set region                us-east-1
 aws configure --profile object-store set endpoint_url          https://objectstore.surf.nl
 aws --profile object-store s3 mb s3://<username>-test-bucket && aws --profile object-store s3 ls
 ```
-Success here = onboarding done. Hand off to [[objectstore-experiments]] to
+Success here = onboarding done. Hand off to /objectstore-experiments to
 exercise features.
 
 ## 7. Legacy Keystone path (only if you were NOT given an S3 key)
@@ -119,4 +119,4 @@ Docs: `https://servicedesk.surf.nl/wiki/spaces/WIKI/pages/112591313/`
 - **Personal vs project accounts**: a personal test account is not for production
   data — request a separate account for a real project.
 - For Ceph-vs-AWS behavioural quirks and runnable feature demos, see
-  [[objectstore-experiments]].
+  /objectstore-experiments.

--- a/.claude/skills/objectstore-onboarding/SKILL.md
+++ b/.claude/skills/objectstore-onboarding/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: objectstore-onboarding
+description: Take a user from "granted access" to a working, least-privilege setup on the SURF Object Store (Ceph RGW, S3-compatible at objectstore.surf.nl) — detect the account type, install/configure aws-cli, split a privileged root profile from a non-root working profile, and verify S3 access. Use when onboarding to Object Store, setting up aws profiles for objectstore.surf.nl, or debugging a login 401/AccessDenied.
+---
+
+# objectstore-onboarding
+
+End-to-end path to get a user running on the **SURF Object Store**, an
+S3-compatible service backed by **Ceph RGW** in SURF's Amsterdam data centers
+(endpoint `https://objectstore.surf.nl`). Distilled from the SURF servicedesk
+docs (Object Store landing + IAM account quickstart) and verified against a live
+CEDA account; the profile names align with the `object-store-evaluation` repo's
+boto3 notebooks.
+
+**Account creation itself needs a SURF admin** — you cannot self-provision. If no
+account/project exists yet, the first step is a servicedesk request; the rest of
+this workflow starts once SURF has sent credentials.
+
+## Workflow
+
+When the user invokes `/objectstore-onboarding [optional: project name]`, walk
+these steps in order. First determine the account type (step 1) — it decides
+which auth path applies.
+
+## 1. Determine the account type
+
+SURF Object Store has **two** auth mechanisms; using the wrong one is the most
+common cause of a `401`.
+
+| Account | Auth | How you got it | Path |
+|---------|------|----------------|------|
+| **New (preferred)** | Ceph **internal IAM** | SURF emailed an S3 **access + secret key** for a root user | steps 2–6 |
+| **Legacy** | OpenStack **Keystone** | you set `OS_*` env vars and run `openstack ec2 credentials create` | step 7 |
+
+**If you were emailed an S3 access + secret key → new IAM account.** Ignore
+Keystone/`openstack` entirely and follow steps 2–6. Quickstart:
+`https://servicedesk.surf.nl/wiki/spaces/WIKI/pages/302481491/`
+
+## 2. Install aws-cli
+```bash
+brew install awscli   # the FORMULA — there is no awscli cask; installing a "cask" installs nothing
+aws --version         # want v2.13+; it honors endpoint_url in config, so no per-command --endpoint-url
+```
+
+## 3. Configure the root profile (privileged — manage users only)
+Name it for the project, e.g. `ceda-root`. **Never** name it `default`.
+```bash
+aws configure --profile ceda-root set aws_access_key_id     <ACCESS_KEY>
+aws configure --profile ceda-root set aws_secret_access_key <SECRET_KEY>
+aws configure --profile ceda-root set region                us-east-1     # dummy; RGW ignores it
+aws configure --profile ceda-root set endpoint_url          https://objectstore.surf.nl
+aws --profile ceda-root s3 ls        # empty output = authenticated OK
+```
+
+## 4. Rotate the emailed key
+The key travelled over email + a one-time link, so replace it. **Order matters:
+delete the old key only after the new one is confirmed working.**
+```bash
+aws --profile ceda-root iam create-access-key            # copy the new pair
+aws configure --profile ceda-root set aws_access_key_id     <NEW_ID>
+aws configure --profile ceda-root set aws_secret_access_key <NEW_SECRET>
+aws --profile ceda-root s3 ls                            # confirm, THEN:
+aws --profile ceda-root iam delete-access-key --access-key-id <OLD_ID>
+```
+
+## 5. Create a non-root working user
+```bash
+aws --profile ceda-root iam create-user --user-name <username>
+aws --profile ceda-root iam create-access-key --user-name <username>   # copy the pair
+aws --profile ceda-root iam attach-user-policy --user-name <username> \
+    --policy-arn arn:aws:iam::aws:policy/AmazonS3FullAccess              # S3 yes, IAM no
+```
+The AWS-managed `AmazonS3FullAccess` ARN works on Ceph RGW.
+
+## 6. Configure the working profile — name it `object-store`
+The `object-store-evaluation` notebooks call `boto3.Session(profile_name="object-store")`,
+so use that exact name and they (and [[objectstore-experiments]]) work unchanged.
+```bash
+aws configure --profile object-store set aws_access_key_id     <NONROOT_ID>
+aws configure --profile object-store set aws_secret_access_key <NONROOT_SECRET>
+aws configure --profile object-store set region                us-east-1
+aws configure --profile object-store set endpoint_url          https://objectstore.surf.nl
+aws --profile object-store s3 mb s3://<username>-test-bucket && aws --profile object-store s3 ls
+```
+Success here = onboarding done. Hand off to [[objectstore-experiments]] to
+exercise features.
+
+## 7. Legacy Keystone path (only if you were NOT given an S3 key)
+Set env vars, then mint EC2 credentials. SURF CUA users use `CuaUsers` for both
+domains; local Keystone users use `Default`.
+```bash
+export OS_AUTH_URL=https://objectstore.surf.nl:5000/v3
+export OS_IDENTITY_API_VERSION=3
+export OS_USERNAME=<user>  OS_PASSWORD=<pw>  OS_PROJECT_NAME=<project>
+export OS_USER_DOMAIN_NAME=CuaUsers  OS_PROJECT_DOMAIN_NAME=CuaUsers
+openstack token issue            # isolates auth failures from the ec2 step
+openstack ec2 credentials create # yields access + secret S3 keys
+```
+Docs: `https://servicedesk.surf.nl/wiki/spaces/WIKI/pages/112591313/`
+
+## Debugging a 401 / AccessDenied
+- **Wrong flow for the account type**: you ran `openstack ...` on an IAM account
+  (or the reverse). Re-check which credential type SURF sent.
+- **Legacy `openstack` 401**: wrong `OS_PASSWORD`, wrong domain (`Default` vs
+  `CuaUsers`), or no access to `OS_PROJECT_NAME`. Isolate with `openstack token
+  issue`, then `openstack project list`.
+- **No project yet**: onboarding is partly manual on SURF's side — the
+  account/project may need creating before any command works. Request it via the
+  servicedesk (state the project name and whether it must be created).
+
+## Important
+- **Least privilege**: do daily work as the non-root `object-store` user; use the
+  root profile *only* to create/rotate users and policies.
+- **Credentials are secrets**: keep `~/.aws/{config,credentials}` at mode `600`,
+  never commit them, never paste them into chats/logs/issues. Prefer named
+  profiles over hardcoded keys (why the eval notebooks reference profiles by name).
+- **Rotate** any key that has been transmitted; `create-access-key` +
+  `delete-access-key` retires one in seconds.
+- **Personal vs project accounts**: a personal test account is not for production
+  data — request a separate account for a real project.
+- For Ceph-vs-AWS behavioural quirks and runnable feature demos, see
+  [[objectstore-experiments]].


### PR DESCRIPTION
# Pull Request Description

## Type of Change
- [x] New feature

## Description of Changes
Voegt twee Claude-skills toe voor de **SURF Object Store** (Ceph RGW, S3-compatible op `objectstore.surf.nl`). Beide zijn **gegrond in de SURF-servicedesk-docs** (Object Store landing + IAM account quickstart) en geverifieerd tegen een live CEDA-account:

- **objectstore-onboarding** (*Workflow*) — de weg van "toegang gekregen" naar een werkende, least-privilege setup: account-type bepalen (Ceph **IAM** vs legacy **Keystone**), `aws-cli` installeren/configureren, een **root**-profiel splitsen van een **non-root** werk-profiel (`object-store`), de gemailde key roteren, en S3-toegang verifiëren. Volgt de `sdp-onboard` Workflow-vorm (`## Workflow`, genummerde stappen) uit #43.
- **objectstore-experiments** (*Kennis*) — S3-features verifiëren met boto3 (versioning, lifecycle, multipart, SSE-C, presigned URLs) plus de **Ceph-vs-AWS-quirks** die empirisch bevestigd zijn: SigV2-default op presigned URLs, SSE-C als enige at-rest-encryptie (`aws:kms` → 400), key-fouten als `400 InvalidArgument` i.p.v. `403`, lifecycle-regels die `Filter`→`Prefix` genormaliseerd terugkomen, en de `-N` multipart-ETag. Volgt de Kennis-vorm (`## When this applies`) uit #47. Bevat vijf runnable reference-scripts onder `objectstore-experiments/scripts/`.

## Related Issues
Vervolg op de skill-PR's #42 (workflow), #43 (SDP/platform) en #46 (app-integration), en de Kennis-conventie uit #47.

## Testing Instructions
- Frontmatter (`name`/`description`) geldig in beide `SKILL.md`.
- Geen machine-specifieke paden of persoonlijke verwijzingen.
- Interne `[[skill]]`-verwijzingen resolven (`objectstore-onboarding` ↔ `objectstore-experiments`, beide binnen deze PR).
- De gebundelde `scripts/experiment_*.py` draaien tegen het `object-store`-profiel en ruimen hun eigen bucket op.

## Dependencies
Geen nieuwe. De skills/scripts verwijzen naar bestaande tooling (`aws` cli v2, `boto3`, `requests`, `openstack` voor legacy accounts).

## Additional Information
De vijf `scripts/experiment_*.py` zijn gebundeld in de skill (net als de `scripts/`-bundels in de SDP-skills uit #43) en zijn ook als notebooks aanwezig in de `object-store-evaluation`-repo (SDA GitLab).

## Checklist
- [x] My code follows the project's coding standards
- [x] I have updated the documentation accordingly (skills zijn zelf de documentatie)

🤖 Generated with [Claude Code](https://claude.com/claude-code)