### PR TITLE
Add personal-data skills; document ETL/infra procedures

### DIFF
--- a/.claude/skills/browser-pseudonymize/SKILL.md
+++ b/.claude/skills/browser-pseudonymize/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: browser-pseudonymize
+description: >-
+  Encrypt or pseudonymize sensitive columns (BSN, PGN, onderwijsnummer) in the
+  user's browser via Pyodide/WebAssembly in a CEDA Streamlit app, so plaintext
+  identifiers never reach the server. Use whenever you build or debug in-browser
+  encryption of personal data, a Pyodide/WASM Streamlit page, an st_js /
+  st_js_blocking / streamlit-js component, or handle BSN/PGN/onderwijsnummer in a
+  Streamlit upload — even if the user only pastes a stuck Pyodide page or asks
+  "how do we encrypt before upload?".
+---
+
+# Browser-side pseudonymization (Pyodide / WebAssembly)
+
+CEDA Streamlit apps that handle personal data (BSN, persoonsgebonden nummer,
+onderwijsnummer) encrypt the sensitive column **in the user's browser** before
+anything is uploaded — the server only ever sees ciphertext. This is done with
+**Pyodide** (CPython compiled to WebAssembly) running the `cryptography` package
+client-side, driven from Streamlit via `streamlit_js`. Grounded in `1cijferho`
+(`src/frontend/Files/`), which is the clean, refactored version; `1cijfer-config`
+has an older inline-HTML generation of the same idea.
+
+## When this applies
+
+This is a **knowledge skill** — it loads (explicitly via `/browser-pseudonymize`,
+or automatically) when you build or debug in-browser encryption of personal data,
+a Pyodide/WASM Streamlit page, an `st_js`/`st_js_blocking` component, or touch
+BSN/PGN/onderwijsnummer in a Streamlit upload. It is reference/convention, not a
+step-by-step procedure.
+
+## Encrypt vs. pseudonymize — pick the right one
+
+These are **different operations** and mixing them up is a governance error, not a
+style choice. Both live in `1cijferho`:
+
+- **Reversible encryption** (browser) — `Fernet` (AES-128-CBC) with a
+  password-derived key. The owner can decrypt later with the password. Use when
+  the original value must be recoverable (e.g. a controlled re-identification
+  flow). File: `src/frontend/Files/js/encrypt_upload.js`.
+- **Irreversible pseudonymization** (server-side) — keyed **HMAC-SHA256**. Same
+  input + same key → same pseudonym (so longitudinal linking within one
+  institution still works), but the original is **not** recoverable. Use for
+  analysis datasets where you never need the BSN back. File:
+  `src/eencijferho/utils/pseudonymizer.py`.
+
+If the task says "so we can still join across years but never reverse it" →
+pseudonymize (HMAC). If it says "the uploader must be able to get the value back"
+→ encrypt (Fernet). Never SHA256 a BSN **without a salt or key** — that is a
+lookup table waiting to happen (this exact mistake was SURF-flagged in an earlier
+1cijferho version).
+
+## The Pyodide-in-Streamlit pattern
+
+The page is a normal Streamlit script; the crypto runs in the browser.
+
+```
+src/frontend/Files/
+├── Encrypt_Upload.py           # Streamlit page (Python, server-side)
+└── js/
+    ├── _pyodide_bootstrap.js    # loads Pyodide once/session + micropip install
+    ├── encrypt_upload.js        # the browser crypto (runs client-side)
+    └── ...                      # decrypt / upload companions
+```
+
+**Bootstrap** (`_pyodide_bootstrap.js`) — cache the Pyodide instance on `window`
+so it loads once per browser session (the first load is 10–20s), then
+`micropip.install('cryptography')`:
+
+```js
+if (!window.__pyodidePromise) {
+    window.__pyodidePromise = (async () => {
+        const { loadPyodide } = await import("https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.mjs");
+        const py = await loadPyodide();
+        await py.loadPackage(["micropip"]);
+        await py.runPythonAsync(`import micropip; await micropip.install('cryptography')`);
+        return py;
+    })();
+}
+const py = await window.__pyodidePromise;
+```
+
+**JS injection helper** — keep the JS in separate template files (not one giant
+inline HTML string — that is the `1cijfer-config` anti-pattern). Inject the
+bootstrap and a single base64 JSON payload via placeholders:
+
+```python
+def _load_js(name: str, payload_b64: str) -> str:
+    template = (_JS_DIR / name).read_text(encoding="utf-8")
+    bootstrap = (_JS_DIR / "_pyodide_bootstrap.js").read_text(encoding="utf-8")
+    return template.replace("// __PYODIDE_BOOTSTRAP__", bootstrap).replace(
+        "__PAYLOAD_B64__", payload_b64)
+```
+
+Pass **all** inputs (CSV, password, column) as one base64-encoded JSON blob, not
+as string concatenation — this avoids breaking the JS on quotes/newlines in the
+data.
+
+**Per-row salt + PBKDF2** — each row gets its own random 16-byte salt, written to
+a `salt` column so the value can be decrypted later without a shared,
+source-baked salt. Key derivation is PBKDF2HMAC-SHA256, 100 000 iterations; the
+column is encrypted with Fernet. Only the ciphertext CSV is returned to Python.
+
+## The async component gotcha (st_js_blocking)
+
+`st_js_blocking` calls `st.stop()` and only returns a result on a **later
+rerun**. If you gate the work directly on `st.button()`, the async result is
+dropped on the next rerun. **Latch the click in `session_state`:**
+
+```python
+if st.button("Versleutelen & opslaan", type="primary"):
+    st.session_state["encrypt_upload_running"] = True
+
+if st.session_state.get("encrypt_upload_running"):
+    raw = st_js_blocking(js, key="encrypt_upload_js")
+    st.session_state["encrypt_upload_running"] = False   # clear so rerun doesn't reprocess
+    # raw may be None/incomplete on an intermediate rerun — guard the json.loads
+```
+
+Always guard the parse: a `None`/non-JSON `raw` means the component hasn't
+returned yet or failed — show an error and `st.stop()`, don't proceed.
+
+## Where the ciphertext goes
+
+After the browser returns the encrypted CSV, the server stores it — in
+`1cijferho` to both MinIO and PostgreSQL via the `get_backend(...)` storage
+abstraction. Splitting a record across a sensitive table, a regular table, and a
+MinIO object (keyed by a derived UUID) is a separate pattern — see
+`/identifier-mapping`.
+
+## Important
+
+- **Encrypt (Fernet, reversible) ≠ pseudonymize (HMAC, irreversible)** — choose
+  deliberately; it is a governance decision. See the table above.
+- **Never SHA256 a BSN without a salt/key** — it is trivially reversible via a
+  precomputed table (a SURF-flagged CEDA incident). Per-row salt (encryption) or
+  a secret key (HMAC pseudonymization) is mandatory.
+- **Keep the HMAC/UUID key server-side** — a client-side key lets anyone forge
+  pseudonyms for a known BSN (the BSN space is small and brute-forceable). The
+  browser password (Fernet) is fine client-side because it's the user's own.
+- **Enforce a strong key** — the server-side pseudonymization key must be
+  ≥64 bytes (HMAC-SHA256 block size); `load_key()` raises below that.
+- **Latch `st_js_blocking` in `session_state`** — gating on `st.button()` drops
+  the async result; always guard the result parse.
+- Keep JS in **separate template files** injected via a helper, not one inline
+  HTML blob (the `1cijfer-config` version is the anti-pattern to avoid).
+- Governance framing (grondslag, bewaartermijn, who may re-identify) is out of
+  scope here — this skill covers the *mechanism*, not the policy.
+- Applies to cedanl repos (grounded in `1cijferho`).

--- a/.claude/skills/etl-pipeline/SKILL.md
+++ b/.claude/skills/etl-pipeline/SKILL.md
@@ -51,6 +51,21 @@ Built image is deployed via the GitLab/SDP flow (cross-pipeline trigger hands th
 image digest to the config repo). See /gitlab-ci and /surf-sdp-helm-flux
 (deploy by **image digest**, not floating tags).
 
+### Wire the cross-pipeline trigger (one-time, per new ETL repo)
+The ETL repo's pipeline triggers the **config** repo's pipeline. Set this up once:
+1. In the **config repo** (e.g. `instroom-config`): Settings → CI/CD → **Pipeline
+   trigger tokens** → *Add new token*. Describe it (e.g. `etl-ho-build`), no
+   expiration → **Create pipeline trigger token**.
+2. In the **ETL repo** (e.g. `instroom-etl-ho`): Settings → CI/CD → **Variables**
+   → *Add variable*. Key `INSTROOM_CONFIG_TRIGGER_TOKEN`, value = the token,
+   available for all environments, visible. The `.gitlab-ci.yml` trigger step
+   then works.
+Source: `instroom-config/docs/transport.md`. The token is a **secret** — it lives
+as a CI variable, never in a committed file.
+
+> Bootstrapping a brand-new ETL repo (copy + regex-rename from an existing one,
+> secret/config setup) is also documented in `instroom-config/docs/transport.md`.
+
 ## Important
 - **Verify a run actually lands the file in MinIO** (list the bucket) before
   calling it done — a silent download failure returns `None`, which the step must

--- a/.claude/skills/identifier-mapping/SKILL.md
+++ b/.claude/skills/identifier-mapping/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: identifier-mapping
+description: >-
+  Split a record with a sensitive identifier (BSN, PGN, onderwijsnummer) into a
+  derived UUID plus a dual PostgreSQL table + MinIO object store in a CEDA app,
+  so the sensitive value and the analysis data live apart. Use when building or
+  debugging the personal-data upload/store/read/delete flow, the
+  secret_sensitive / secret_regular tables, UUID derivation from a BSN, or the
+  init.sql schema for personal data in 1cijferho / 1cijfer-config.
+---
+
+# Identifier mapping (UUID + dual Postgres table + MinIO)
+
+CEDA personal-data apps store an uploaded record **split across three
+destinations**, keyed by a UUID derived from the sensitive identifier — so the
+sensitive columns, the demographic columns, and the bulk data never sit together.
+Grounded in `1cijferho` (`src/eencijferho/io/personal_data.py`, `init.sql`), with
+an earlier FastAPI variant in `1cijfer-config` (`src/api/routers/upload.py`).
+
+## When this applies
+
+This is a **knowledge skill** — it loads (explicitly via `/identifier-mapping`,
+or automatically) when you build or debug the personal-data upload/store/read/
+delete flow, the `secret_sensitive`/`secret_regular` tables, UUID derivation from
+a BSN/PGN, or the personal-data `init.sql`. It is reference/convention, not a
+step-by-step procedure.
+
+## The three destinations
+
+```
+uploaded record  ──derive_uuid(PGN)──►  uuid  (the join key everywhere)
+                                         │
+   ┌─────────────────────────────────────┼─────────────────────────────────────┐
+   ▼                                      ▼                                       ▼
+secret_sensitive (Postgres)      secret_regular (Postgres)            MinIO JSON object
+ uuid + encrypted IDs + salt      uuid + demographics                  uuid + everything else
+                                  FK → secret_sensitive
+                                  ON DELETE CASCADE
+```
+
+The UUID is the only thing shared across all three. `secret_regular` has a
+foreign key to `secret_sensitive` with `ON DELETE CASCADE`, so deleting the
+sensitive row removes the demographic row automatically; the code deletes the
+MinIO object explicitly alongside it.
+
+## UUID derivation — keyed HMAC, server-side
+
+The UUID is derived from the plaintext identifier (persoonsgebonden nummer) via
+**keyed HMAC-SHA256**, formatted as a UUID string:
+
+```python
+def derive_uuid(source: str) -> str:
+    h = hmac.new(_uuid_key(), str(source).encode("utf-8"), hashlib.sha256).hexdigest()
+    return f"{h[:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}"
+```
+
+Why keyed, and why server-side: the same PGN always maps to the same UUID (so
+records for the same person link up), but the key stays on the server so the
+mapping can't be recomputed by a client — the BSN/PGN search space is small
+enough to brute-force a keyless hash. The plaintext `__uuid_source` is used to
+compute the UUID and then **dropped — never stored**. See the encryption side in
+`/browser-pseudonymize`.
+
+> **1cijfer-config variant:** the older FastAPI version instead assigns a random
+> `uuid.uuid4()` and stores the `(uuid, bsn)` pair in a `sensitive` mapping table,
+> uploading the de-identified CSV to a `processed` bucket and the original to an
+> `original` bucket. That's a mapping table (reversible via the DB) rather than a
+> derived pseudonym — a different trade-off. Prefer the `1cijferho` HMAC-derived
+> approach for new work unless you specifically need a stored reverse map.
+
+## Read-back at three resolution levels
+
+`view_file(filename, mode=...)` joins progressively more back in — grant the least
+that answers the question:
+
+| mode | returns | joins |
+|---|---|---|
+| `raw` | MinIO object only (uuid + extra fields) | none |
+| `with_regular` | + demographics | `secret_regular` |
+| `with_encrypted` | + still-encrypted sensitive fields | both tables |
+
+Note `with_encrypted` returns the sensitive columns **still encrypted** (plus the
+`salt`) — the join never decrypts; decryption is the browser's job.
+
+## Schema (init.sql)
+
+`secret_sensitive` (uuid PK, the identifier columns, a per-row `salt`,
+`created_at`) and `secret_regular` (uuid PK + FK, demographic VARCHARs,
+`created_at`). Loaded by the Postgres container via `docker-entrypoint-initdb.d`.
+The code's `ensure_schema()` also creates the tables if missing, and `get_schema()`
+reads the live column list from `information_schema` (falling back to defaults),
+so the flow adapts to schema changes without hardcoding column lists.
+
+## Not yet implemented (don't claim otherwise)
+
+`corneel_notes.txt` lists these as intended, but they are **not** in the code as
+of this writing — flag them as design intent, not fact, if asked:
+
+- **A restricted DB user** with rights only on the mapping tables — not created;
+  the app uses the default `POSTGRES_USER`. `CREATE ROLE ... GRANT` is TODO.
+- **PL/pgSQL stored procedures** — none; all logic is Python.
+- **Constraints** INT(9) / unique-BSN / unique-HASH — not enforced; identifiers
+  are stored as TEXT/VARCHAR with uniqueness only via the uuid primary key.
+
+If a task asks to "finish" this pattern, these three are the real gaps.
+
+## Important
+
+- **Derive the UUID with a server-side keyed HMAC** — never a keyless hash of a
+  BSN (brute-forceable; a SURF-flagged CEDA incident). Key never reaches the
+  client. See `/browser-pseudonymize`.
+- **The plaintext identifier is used then dropped** — `__uuid_source` is never
+  written to any store.
+- **Deletion must hit all three stores** — the FK cascades Postgres, but the
+  MinIO object is deleted explicitly; dropping only one leaves orphaned personal
+  data.
+- **Grant the least resolution** that answers the question (`raw` <
+  `with_regular` < `with_encrypted`); the sensitive join returns ciphertext, not
+  plaintext.
+- Restricted DB user, stored procedures, and INT-9/unique constraints are
+  **design intent, not implemented** — say so.
+- Storage goes through the `get_backend(...)` abstraction (Postgres + MinIO) —
+  see `/etl-pipeline` and `/sdp-secrets-management` for how those backends get
+  their config in deployed environments.
+- Applies to cedanl repos (grounded in `1cijferho`, older variant in
+  `1cijfer-config`).

--- a/.claude/skills/surf-sdp-helm-flux/SKILL.md
+++ b/.claude/skills/surf-sdp-helm-flux/SKILL.md
@@ -7,8 +7,10 @@ description: >-
   or deploy Helm charts, debugs a failing or stuck HelmRelease, sees Flux
   reconciliation problems, hits 401/404 errors pulling charts from an OCI
   registry, encounters chart version mismatches in deploy verification, sets
-  up cross-pipeline triggers, or mentions SDP, Harbor, cr.surf.nl, FluxCD,
-  HelmRepository, or HelmRelease — even if they only paste a pipeline log or
+  up cross-pipeline triggers, work on a Kubernetes CronJob or on-demand Job Helm
+  template for scheduled/triggered batch runs, or mentions SDP, Harbor,
+  cr.surf.nl, FluxCD, HelmRepository, or HelmRelease — even if they only paste a
+  pipeline log or
   kubectl output without an explicit question.
 ---
 
@@ -208,6 +210,59 @@ Protected ✓). If a job stays "pending" with a runner that is online and
 correctly tagged, check this flag before anything else — the symptom looks
 exactly like a tagging problem but isn't.
 
+## Batch workloads: scheduled CronJob + on-demand Job
+
+ETL/ML steps run as batch workloads, not long-lived Deployments. The `instroom`
+chart (`instroom-config/charts/instroom/templates/{etl,ml}/`) is the reference:
+per service (`etlwo`, `etlho`, `ml`) it ships **two** templates, each gated by its
+own `.Values.<svc>` flag:
+
+- **`cron_<svc>.yaml`** — `kind: CronJob`, gated by `.Values.<svc>.cronJob.enabled`,
+  with `schedule` (e.g. `"0 2 * * *"`), `concurrencyPolicy`, history limits and
+  deadlines. This is the *scheduled* path.
+- **`job_<svc>.yaml`** — `kind: Job`, gated by `.Values.<svc>.job.enabled`. This is
+  the **on-demand** path: the pipeline flips `job.enabled=true` (via
+  `HELM_UPGRADE_ARGS --set <svc>.job.enabled=true`, see cross-pipeline triggers
+  above) and a fresh Job runs.
+
+### On-demand = unique Job name per release
+
+A plain `kind: Job` is immutable once created, so re-applying with the same name
+does nothing. The chart makes each Helm release spawn a **new** Job by suffixing
+the name with the release revision + random string:
+
+```yaml
+metadata:
+  name: {{ include "instroom.fullname" . }}-<svc>-job-{{ .Release.Revision }}-{{ randAlphaNum 8 | lower }}
+```
+
+That is the whole "on-demand (unscheduled) cron job" mechanism from the notes:
+a trigger → Helm upgrade → new revision → new Job name → it runs once.
+
+### Both pull image by digest and env from the config/secret
+
+The job containers select the image by `sha256:` digest when the tag is a digest
+(same digest-not-tag rule as Deployments), and take MinIO/etc. config from the
+Flux-managed ConfigMap + Secret (`envFrom` a `configMapRef`/`secretRef`, or
+`valueFrom` on `existingConfigMap`/`existingSecret`). See `/sdp-secrets-management`
+for where those come from.
+
+### Known bugs in the reference chart (fix if you touch it)
+
+The `instroom` templates have field errors worth correcting before reuse:
+
+- **`cron_<svc>.yaml`** sets `successfulJobsHistoryLimit` **twice** (a duplicate
+  YAML key — the second silently wins), and sets
+  `ttlSecondsAfterFinished` from `activeDeadlineSeconds`, which conflates
+  "how long the finished object lingers" with "how long the run may take". Set
+  `ttlSecondsAfterFinished` from its own value.
+- **`job_<svc>.yaml`** carries `successfulJobsHistoryLimit` /
+  `failedJobsHistoryLimit` — these are **CronJob-only** fields and are invalid on
+  a `kind: Job`. Drop them from the Job spec.
+
+Validate any change with `helm template` / `kustomize build` (see *local preview*
+above) before committing.
+
 ## Troubleshooting quick reference
 
 | Symptom | Likely cause | First action |
@@ -243,5 +298,10 @@ suspend/resume, checking Kustomization sync, job log retrieval), read
   the next sync reverts them; fix the source repo instead.
 - Check the `+`↔`_` OCI-tag spelling before assuming a chart is missing.
 - Deploy by **image digest**, not floating tags.
+- **Batch runs** = scheduled `CronJob` + on-demand `Job`; on-demand relies on a
+  unique Job name per release (`{{ .Release.Revision }}-{{ randAlphaNum 8 }}`).
+  The reference `instroom` chart has field bugs (duplicate
+  `successfulJobsHistoryLimit`, wrong `ttlSecondsAfterFinished`, CronJob-only keys
+  on a `Job`) — fix them if you reuse it.
 - This is a **GitLab/SDP** skill — use `glab`/kubectl, not `gh` or GitHub Actions.
 - Applies to cedanl / SURF SDP repos.

--- a/.claude/skills/surfdrive/SKILL.md
+++ b/.claude/skills/surfdrive/SKILL.md
@@ -21,6 +21,19 @@ Both are provided via `.env` locally (compose reads `${SURFDRIVE_*}`) and via
 SOPS-encrypted secrets in deployed environments — see /sdp-secrets-management.
 Never commit them in plaintext.
 
+## Create the public share (where the token + password come from)
+When a new source file needs to be ingested, create the share by hand in the
+SurfDrive web UI (there is no API step in the CEDA flow):
+1. Log in at `https://surfdrive.surf.nl/` and drag-and-drop the CSV to upload it.
+2. Select the file → **Public Links** tab → **Create public link**. Give it a
+   descriptive name (e.g. `instroom-csv-ho`) and set a **password**.
+3. **Copy to clipboard** yields a URL like
+   `https://surfdrive.surf.nl/files/index.php/s/flr4TPVH6io9JEn`.
+The trailing id (`flr4TPVH6io9JEn`) is `SURFDRIVE_SHARE_TOKEN`; the password you
+set is `SURFDRIVE_PASSWORD`. Put both into the deployment secret via SOPS (see
+/sdp-secrets-management) — not into any committed file. Source:
+`instroom-config/docs/transport.md`.
+
 ## Usage pattern (transport.py)
 ```python
 import surfdrive


### PR DESCRIPTION
# Pull Request Description

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Enhancement
- [x] Documentation update
- [ ] Other (please specify)

## Description of Changes
Codifies procedures that were documented (in `corneel_notes.txt` and the `instroom`/`1cijferho` implementations) but not yet captured as skills. All content is grounded in real, verified code — not planning notes.

**New knowledge skills**
- **`browser-pseudonymize`** — in-browser Pyodide/WebAssembly encryption of sensitive columns (BSN/PGN/onderwijsnummer) before upload, in a Streamlit app. Captures the encrypt-vs-pseudonymize distinction, the "never keyless-hash a BSN" rule, the Pyodide bootstrap/caching, base64 JS-payload injection, and the `st_js_blocking` session-state latching gotcha. Grounded in `1cijferho/src/frontend/Files/`.
- **`identifier-mapping`** — split a record into a derived UUID + dual Postgres tables (`secret_sensitive`/`secret_regular`, FK cascade) + a MinIO object. Server-side keyed-HMAC UUID derivation; three read-back resolution levels. Grounded in `1cijferho/src/eencijferho/io/personal_data.py`.

**Extended skills**
- **`surf-sdp-helm-flux`** — new "Batch workloads" section: scheduled `CronJob` + on-demand `Job`, the unique-name-per-release mechanism, image-by-digest + config/secret wiring. Flags field bugs in the reference `instroom` chart.
- **`etl-pipeline`** — cross-pipeline trigger-token setup (`INSTROOM_CONFIG_TRIGGER_TOKEN`).
- **`surfdrive`** — public-share creation (where `SURFDRIVE_SHARE_TOKEN`/`PASSWORD` come from).

## Related Issues
_None._

## Comparison: Before and After

### Before:
Personal-data handling (browser encryption, UUID/dual-store) and the batch-job / trigger-token / surfdrive-link procedures lived only in code and `corneel_notes.txt`; no skill surfaced them.

### After:
Two new skills + three extended skills codify these patterns, with the security-sensitive parts (encrypt vs pseudonymize, keyed server-side hashing) made explicit.

## Testing Instructions
Skills are markdown (no executable change). To validate:
1. Confirm each `SKILL.md` frontmatter `description` triggers on its intended prompts.
2. Cross-references (`/browser-pseudonymize`, `/identifier-mapping`, `/sdp-secrets-management`, `/etl-pipeline`) resolve to existing skills.

## Validation
- [ ] `styler::style_active_file()` has been run — N/A: no R code

## Dependencies
None.

## Additional Information
- **`identifier-mapping` explicitly marks** the restricted DB user, stored procedures, and INT-9/unique constraints as *design intent, not implemented* — it does not claim code that is absent.
- **Known chart bugs** in `instroom-config` (duplicate `successfulJobsHistoryLimit`, misused `ttlSecondsAfterFinished`, CronJob-only keys on a `Job`) are documented in the skill but **not fixed here** — that is a separate change in the `instroom-config` repo.
- Relates to the merge backlog noted in `docs/skill-gaps.md`: please review promptly rather than letting it queue.

## Checklist
- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly
- [x] My code follows the project's coding standards
- [ ] I have added/updated tests to cover my changes (if applicable) — N/A: docs-only
- [x] The code is accompanied by comments
- [ ] I have linked this PR to relevant issues (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
